### PR TITLE
fix: supporting invalid safe address parameter in json

### DIFF
--- a/action-scripts/merge_pr_jsons.py
+++ b/action-scripts/merge_pr_jsons.py
@@ -133,7 +133,8 @@ def main():
             safe_address = file["meta"]["createdFromSafeAddress"]
             if not safe_address:
                 safe_address = file["meta"]["createFromSafeAddress"]
-            grouped_files[safe_address].append(file)
+            if safe_address and isinstance(safe_address, str):
+                grouped_files[safe_address].append(file)
 
         # Now we have a list of files grouped by safe address, let's merge them and save to files
         for safe_address, fs in grouped_files.items():


### PR DESCRIPTION
This PR skips invalid params `createFromSafeAddress` to not to fail action.

Example of invalid payload is here https://github.com/BalancerMaxis/multisig-ops/blob/main/BIPs/2023-W23/BIP-318/avalanche.json

with `"createFromSafeAddress": {}`

`"createFromSafeAddress"` param should be filled so we can group by msig address in merging script, cc @Tritium-VLK @solarcurvey 