### PR TITLE
feat: add chain headers to each file reported

### DIFF
--- a/action-scripts/brownie/scripts/report_gauge_add.py
+++ b/action-scripts/brownie/scripts/report_gauge_add.py
@@ -107,6 +107,7 @@ def _parse_added_transaction(transaction: dict) -> Optional[dict]:
         "fee": f"{fee}%",
         "cap": gauge_cap,
         "style": style,
+        "chain": chain if chain else "mainnet",
     }
 
 


### PR DESCRIPTION
Reports will now have additional header displaying all chains present in file's tx list like this:

```
File name: BIPs/2023-W24/BIP-328.json
COMMIT: `1a2b3c4d5e6f7g8h9i0j`
CHAIN(S): `zkevm`
```