### PR TITLE
feat: Parse bip number and transaction index

### DIFF
--- a/action-scripts/brownie/scripts/report_gauges.py
+++ b/action-scripts/brownie/scripts/report_gauges.py
@@ -10,6 +10,7 @@ from .script_utils import format_into_report
 from .script_utils import get_changed_files
 from .script_utils import get_pool_info
 from .script_utils import merge_files
+from .script_utils import extract_bip_number
 
 ADDR_BOOK = AddrBook("mainnet")
 FLATBOOK = ADDR_BOOK.flatbook
@@ -136,6 +137,8 @@ def _parse_added_transaction(transaction: dict, **kwargs) -> Optional[dict]:
         "cap": gauge_cap,
         "style": style,
         "chain": chain if chain else "mainnet",
+        "bip": kwargs.get('bip_number', 'N/A'),
+        "transaction_index": kwargs.get('tx_index', 'N/A'),
     }
 
 
@@ -189,6 +192,8 @@ def _parse_removed_transaction(transaction: dict, **kwargs) -> Optional[dict]:
         "cap": gauge_cap,
         "style": style,
         "chain": chain if chain else "mainnet",
+        "bip": kwargs.get('bip_number', 'N/A'),
+        "transaction_index": kwargs.get('tx_index', 'N/A'),
     }
 
 
@@ -233,7 +238,9 @@ def _parse_transfer(transaction: dict, **kwargs) -> Optional[dict]:
         "token_address": token.address,
         "recipient_address": recipient_address,
         "raw_amount": raw_amount,
-        "chain": chain_name
+        "chain": chain_name,
+        "bip": kwargs.get('bip_number', 'N/A'),
+        "transaction_index": kwargs.get('tx_index', 'N/A'),
     }
 
 
@@ -246,8 +253,12 @@ def handler(files: list[dict], handler_func: Callable) -> dict[str, str]:
     for file in files:
         outputs = []
         tx_list = file["transactions"]
+        bip_number = extract_bip_number(file)
         for transaction in tx_list:
-            data = handler_func(transaction, chain_id=file["chainId"])
+            data = handler_func(
+                transaction, chain_id=file["chainId"], bip_number=bip_number,
+                tx_index=tx_list.index(transaction)
+            )
             if data:
                 outputs.append(data)
         if outputs:

--- a/action-scripts/brownie/scripts/report_gauges.py
+++ b/action-scripts/brownie/scripts/report_gauges.py
@@ -253,11 +253,16 @@ def handler(files: list[dict], handler_func: Callable) -> dict[str, str]:
     for file in files:
         outputs = []
         tx_list = file["transactions"]
-        bip_number = extract_bip_number(file)
         for transaction in tx_list:
             data = handler_func(
-                transaction, chain_id=file["chainId"], bip_number=bip_number,
-                tx_index=tx_list.index(transaction)
+                transaction, chain_id=file["chainId"],
+                # Try to extract bip number from transaction meta first. If it's missing,
+                # It means merge jsons hasn't been run yet, so we extract it from the file name
+                bip_number=transaction.get(
+                    'meta', {}).get(
+                    'bip_number'
+                ) or extract_bip_number(file),
+                tx_index=transaction.get('meta', {}).get('tx_index', "N/A")
             )
             if data:
                 outputs.append(data)

--- a/action-scripts/brownie/scripts/script_utils.py
+++ b/action-scripts/brownie/scripts/script_utils.py
@@ -1,6 +1,8 @@
 import json
 import os
+import re
 from json import JSONDecodeError
+from typing import Optional
 
 import requests
 from brownie import Contract
@@ -156,3 +158,22 @@ def merge_files(
             transfers.get(key, ""),
         ])
     return merged_dict
+
+
+def extract_bip_number(bip_file: dict) -> Optional[str]:
+    """
+    Extracts BIP number from file path or from transactions metadata
+    """
+    bip = None
+    # First, try to exctract BIP from file path
+    if bip_file.get('file_name') is not None:
+        bip_match = re.search(r"\bBIP-?\d+[A-Za-z]?\b", bip_file["file_name"])
+        bip = bip_match.group(0) if bip_match else None
+
+    # If no BIP in file path, try to extract it from transactions metadata
+    if not bip:
+        for tx in bip_file['transactions']:
+            if tx.get('meta', {}).get('bip') not in [None, "N/A"]:
+                bip = tx['meta']['bip']
+                break
+    return bip or "N/A"

--- a/action-scripts/brownie/scripts/script_utils.py
+++ b/action-scripts/brownie/scripts/script_utils.py
@@ -173,7 +173,7 @@ def extract_bip_number(bip_file: dict) -> Optional[str]:
     # If no BIP in file path, try to extract it from transactions metadata
     if not bip:
         for tx in bip_file['transactions']:
-            if tx.get('meta', {}).get('bip') not in [None, "N/A"]:
-                bip = tx['meta']['bip']
+            if tx.get('meta', {}).get('bip_number') not in [None, "N/A"]:
+                bip = tx['meta']['bip_number']
                 break
     return bip or "N/A"

--- a/action-scripts/merge_pr_jsons.py
+++ b/action-scripts/merge_pr_jsons.py
@@ -204,12 +204,13 @@ def main():
             result['chainId'] = chain_id
             result["transactions"] = []
             for file in fs:
-                # Parse BIP-XXX number from the file name
-                bip_number = extract_bip_number(file)
-
                 #  Check for gauge adds and generate checkpoint list
                 for tx in file["transactions"]:
-                    tx["meta"] = {"bip_number": bip_number}
+                    tx["meta"] = {
+                        "tx_index": file["transactions"].index(tx),
+                        "origin_file_name": file['file_name'],
+                        "bip_number": extract_bip_number(file),
+                    }
                     if tx["contractMethod"]["name"] == "addGauge":
                         try:
                             gauge_chain = tx["contractInputsValues"]["gaugeType"]


### PR DESCRIPTION
## Done:
Parsing BIP number and tx id from original BIP file.

### Report example look:

File name: BIPs/00batched/2023-W26/1-0x10A19e7eE7d7F8a52822f6817de8ea18204F2e4f.json
COMMIT: `1a2b3c4d5e6f7g8h9i0j`
CHAIN(S): `mainnet`
```
+----------+--------------+--------------------------+----------+--------------------------------------------+--------------------------------------------+-------------------------+---------+-------------------+
| function | token_symbol |      recipient_name      |  amount  |               token_address                |             recipient_address              |        raw_amount       |   bip   | transaction_index |
+----------+--------------+--------------------------+----------+--------------------------------------------+--------------------------------------------+-------------------------+---------+-------------------+
| transfer |     USDC     |   multisigs/foundation   | 93750.0  | 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48 | 0x3B8910F378034FD6E103Df958863e5c684072693 |       93750000000       | BIP-348 |         0         |
| transfer |     USDC     |    multisigs/maxi_ops    | 132630.0 | 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48 | 0x166f54F44F271407f24AA1BE415a730035637325 |       132630000000      | BIP-347 |         0         |
| transfer |     BAL      |    multisigs/maxi_ops    | 25400.0  | 0xba100000625a3754423978a60c9317c58a424e3D | 0x166f54F44F271407f24AA1BE415a730035637325 | 25400000000000000000000 | BIP-347 |         1         |
| transfer |     USDC     | multisigs/beets_treasury | 55000.0  | 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48 | 0x811912c19eEF91b9Dc3cA52fc426590cFB84FC86 |       55000000000       | BIP-314 |         0         |
+----------+--------------+--------------------------+----------+--------------------------------------------+--------------------------------------------+-------------------------+---------+-------------------+
```