### PR TITLE
BIP-477: Enable PSP/OP 80/20 Gauge with 2% emission cap [Optimism]

### DIFF
--- a/BIPs/2023-W45/BIP-477.json
+++ b/BIPs/2023-W45/BIP-477.json
@@ -1,0 +1,40 @@
+{
+  "version": "1.0",
+  "chainId": "1",
+  "createdAt": 1699436003020,
+  "meta": {
+    "name": "Transactions Batch",
+    "description": "Add new gauges",
+    "txBuilderVersion": "1.16.3",
+    "createdFromSafeAddress": "0xc38c5f97B34E175FFd35407fc91a937300E33860",
+    "createdFromOwnerAddress": "",
+    "checksum": ""
+  },
+  "transactions": [
+    {
+      "to": "0x5DbAd78818D4c8958EfF2d5b95b28385A22113Cd",
+      "value": "0",
+      "data": null,
+      "contractMethod": {
+        "inputs": [
+          {
+            "name": "gauge",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "gaugeType",
+            "type": "string",
+            "internalType": "string"
+          }
+        ],
+        "name": "addGauge",
+        "payable": false
+      },
+      "contractInputsValues": {
+        "gauge": "0x132296d1Dfd10bA55b565C4Cfe49D350617a2A2b",
+        "gaugeType": "Optimism"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
- enable PSP/OP gauge on OP with 2% cap
- Tenderly-sim: https://dashboard.tenderly.co/public/safe/safe-apps/simulator/1b615a72-0bc1-4e74-bed5-3a5c85e6d51f