### PR TITLE
chore: bump `web3` dep

### DIFF
--- a/action-scripts/requirements-actions.txt
+++ b/action-scripts/requirements-actions.txt
@@ -2,7 +2,7 @@ munch==4.0.0
 dotmap==1.3.30
 pathlib==1.0.1
 pandas==1.5.3
-web3==5.31.3
+web3==6.11.3
 tabulate==0.9.0
 git+https://github.com/BalancerMaxis/bal_addresses@0.8.5
 


### PR DESCRIPTION
this adds support for python 3.11 as per https://github.com/ethereum/web3.py/pull/2699