### PR TITLE
ci: cache compilers for `brownie` actions

### DIFF
--- a/.github/workflows/merge_json.yaml
+++ b/.github/workflows/merge_json.yaml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       runWeek:
-        description: 'The week to run on like YYYY-W##, should match a directory in BIPs/'
+        description: "The week to run on like YYYY-W##, should match a directory in BIPs/"
         required: true
 
 jobs:
@@ -16,6 +16,14 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
+
+      - name: Cache Compiler Installations
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.solcx
+            ~/.vvm
+          key: compiler-cache
 
       - name: Set up Python
         uses: actions/setup-python@v2
@@ -43,5 +51,5 @@ jobs:
     uses: "BalancerMaxis/multisig-ops/.github/workflows/run_reports_reusable.yaml@main"
     secrets: inherit
     with:
-      pr_number:  ${{ needs.merge_jsons.outputs.pull-request-number }}
+      pr_number: ${{ needs.merge_jsons.outputs.pull-request-number }}
       checkout_ref: "gha-payload-merge"

--- a/.github/workflows/poke_injectors.yaml
+++ b/.github/workflows/poke_injectors.yaml
@@ -3,7 +3,7 @@ name: Poke Onchain Rewards Injectors
 on:
   workflow_dispatch:
   schedule:
-  - cron: "0/5 * * * *"
+    - cron: "0/5 * * * *"
 env:
   KEYWORDS: ${{ secrets.KEEPER_PRIVATE_WORDS }}
   WEB3_INFURA_PROJECT_ID: ${{ secrets.WEB3_INFURA_PROJECT_ID }}
@@ -21,6 +21,14 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
+
+      - name: Cache Compiler Installations
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.solcx
+            ~/.vvm
+          key: compiler-cache
 
       - name: Set up Python
         uses: actions/setup-python@v2

--- a/.github/workflows/run_auth_gen.yaml
+++ b/.github/workflows/run_auth_gen.yaml
@@ -2,7 +2,7 @@ name: Generate new Authorizer Payloads
 
 on:
   pull_request:
-    types: [ labeled, synchronize ]
+    types: [labeled, synchronize]
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -11,27 +11,35 @@ jobs:
   gen_auth:
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout
-      uses: actions/checkout@v2
+      - name: Checkout
+        uses: actions/checkout@v2
 
-    - name: Setup Python 3.9
-      uses: actions/setup-python@v2
-      with:
-        python-version: 3.9
+      - name: Cache Compiler Installations
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.solcx
+            ~/.vvm
+          key: compiler-cache
 
-    - name: Do Work
-      if: ${{ github.event.label.name == 'Generate Authorizer' }}
-      env:
-        WEB3_INFURA_PROJECT_ID: ${{ secrets.WEB3_INFURA_PROJECT_ID }}
-      run: |
-        pwd
-        pip3 install -r action-scripts/requirements-actions.txt
-        python3 action-scripts/gen_add_permissions_payload.py
+      - name: Setup Python 3.9
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
 
-    - name: Commit and push changes
-      uses:  stefanzweifel/git-auto-commit-action@v4
-      with:
-        commit_message: Generate permissions add payload and tables
-        commit_user_name:  GitHub Actions
-        commit_user_email: github-actions[bot]@users.noreply.github.com
-        commit_author: Github Actions <noreply@users.noreply.github.com>
+      - name: Do Work
+        if: ${{ github.event.label.name == 'Generate Authorizer' }}
+        env:
+          WEB3_INFURA_PROJECT_ID: ${{ secrets.WEB3_INFURA_PROJECT_ID }}
+        run: |
+          pwd
+          pip3 install -r action-scripts/requirements-actions.txt
+          python3 action-scripts/gen_add_permissions_payload.py
+
+      - name: Commit and push changes
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: Generate permissions add payload and tables
+          commit_user_name: GitHub Actions
+          commit_user_email: github-actions[bot]@users.noreply.github.com
+          commit_author: Github Actions <noreply@users.noreply.github.com>

--- a/.github/workflows/run_reports_reusable.yaml
+++ b/.github/workflows/run_reports_reusable.yaml
@@ -33,10 +33,18 @@ jobs:
           ref: ${{ inputs.checkout_ref }}
           fetch-depth: 0
 
+      - name: Cache Compiler Installations
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.solcx
+            ~/.vvm
+          key: compiler-cache
+
       - name: Setup Python 3.9
         uses: actions/setup-python@v4
         with:
-          python-version: '3.9'
+          python-version: "3.9"
 
       - name: Setup Environment
         run: |
@@ -68,7 +76,7 @@ jobs:
           else
             echo "validation_exists=false" >> $GITHUB_OUTPUT
           fi
-          
+
           if [ -f "action-scripts/brownie/payload_reports.txt" ]; then
             echo "payload_reports=true" >> $GITHUB_OUTPUT
           else


### PR DESCRIPTION
introduces caching for workflows that rely on `brownie`. prevents having to download all `solc` and `vyper` binaries at every run.

via https://github.com/brownie-mix/github-actions-mix/blob/0bfdd5fab8ece6ab13d757173c9e8f68501ee998/.github/workflows/main.yaml#L22-L28