### PR TITLE
BIP-523: Enable LUMIN/rETH Gauge with 2% emissions cap [Arbitrum]

### DIFF
--- a/BIPs/2023-W51/BIP-523.json
+++ b/BIPs/2023-W51/BIP-523.json
@@ -1,0 +1,40 @@
+{
+  "version": "1.0",
+  "chainId": "1",
+  "createdAt": 1703697640472,
+  "meta": {
+    "name": "Transactions Batch",
+    "description": "Add new gauges",
+    "txBuilderVersion": "1.16.3",
+    "createdFromSafeAddress": "0xc38c5f97B34E175FFd35407fc91a937300E33860",
+    "createdFromOwnerAddress": "",
+    "checksum": ""
+  },
+  "transactions": [
+    {
+      "to": "0x5DbAd78818D4c8958EfF2d5b95b28385A22113Cd",
+      "value": "0",
+      "data": null,
+      "contractMethod": {
+        "inputs": [
+          {
+            "name": "gauge",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "gaugeType",
+            "type": "string",
+            "internalType": "string"
+          }
+        ],
+        "name": "addGauge",
+        "payable": false
+      },
+      "contractInputsValues": {
+        "gauge": "0x8F44a8Cfb7FE682295Fa663348060533732F437C",
+        "gaugeType": "Arbitrum"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
- enable LUMIN-rETH gauge on Arbitrum
- Tenderly-sim: https://dashboard.tenderly.co/public/safe/safe-apps/simulator/7ebec0d4-542e-4f41-a2b8-913c56e8d333