### PR TITLE
BIP-527-2eur-Gauges

### DIFF
--- a/BIPs/2024-W2/BIP-527.json
+++ b/BIPs/2024-W2/BIP-527.json
@@ -1,0 +1,83 @@
+{
+  "version": "1.0",
+  "chainId": "1",
+  "createdAt": 1704378156791,
+  "meta": {
+    "name": "Transactions Batch",
+    "description": "",
+    "txBuilderVersion": "1.16.3",
+    "createdFromSafeAddress": "0x10A19e7eE7d7F8a52822f6817de8ea18204F2e4f",
+    "createdFromOwnerAddress": "",
+    "checksum": "0xfce229b389ca02b21a37a4372c5a0d9c7e39648a05f1974658f3090880c80b8f"
+  },
+  "transactions": [
+    {
+      "to": "0xA331D84eC860Bf466b4CdCcFb4aC09a1B43F3aE6",
+      "value": "0",
+      "data": null,
+      "contractMethod": {
+        "inputs": [
+          { "internalType": "bytes32", "name": "role", "type": "bytes32" },
+          { "internalType": "address", "name": "account", "type": "address" }
+        ],
+        "name": "grantRole",
+        "payable": false
+      },
+      "contractInputsValues": {
+        "role": "0x076e9815202aa39577192023cfa569d6504b003183b2bc13cd0046523dfa23ea",
+        "account": "0x10A19e7eE7d7F8a52822f6817de8ea18204F2e4f"
+      }
+    },
+    {
+      "to": "0xf5dECDB1f3d1ee384908Fbe16D2F0348AE43a9eA",
+      "value": "0",
+      "data": null,
+      "contractMethod": {
+        "inputs": [
+          { "name": "target", "type": "address", "internalType": "address" },
+          { "name": "data", "type": "bytes", "internalType": "bytes" }
+        ],
+        "name": "performAction",
+        "payable": true
+      },
+      "contractInputsValues": {
+        "target": "0x16289F675Ca54312a8fCF99341e7439982888077",
+        "data": "0xd34fb267"
+      }
+    },
+    {
+      "to": "0xA331D84eC860Bf466b4CdCcFb4aC09a1B43F3aE6",
+      "value": "0",
+      "data": null,
+      "contractMethod": {
+        "inputs": [
+          { "internalType": "bytes32", "name": "role", "type": "bytes32" },
+          { "internalType": "address", "name": "account", "type": "address" }
+        ],
+        "name": "grantRole",
+        "payable": false
+      },
+      "contractInputsValues": {
+        "role": "0x076e9815202aa39577192023cfa569d6504b003183b2bc13cd0046523dfa23ea",
+        "account": "0x10A19e7eE7d7F8a52822f6817de8ea18204F2e4f"
+      }
+    },
+    {
+      "to": "0xf5dECDB1f3d1ee384908Fbe16D2F0348AE43a9eA",
+      "value": "0",
+      "data": null,
+      "contractMethod": {
+        "inputs": [
+          { "name": "target", "type": "address", "internalType": "address" },
+          { "name": "data", "type": "bytes", "internalType": "bytes" }
+        ],
+        "name": "performAction",
+        "payable": true
+      },
+      "contractInputsValues": {
+        "target": "0x790DE8ABE859f399023BCe73B5FE5C4870cD816A",
+        "data": "0xab8f0945"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Parts 1 and grant / revoke roles for DAO Multisig to unkill gauges. Part 2 unkills the 2eur gauge 0x16289F675Ca54312a8fCF99341e7439982888077. Part 4 kills the correct 2eur gauge 0x790DE8ABE859f399023BCe73B5FE5C4870cD816A

Simulation: https://dashboard.tenderly.co/public/safe/safe-apps/simulator/72295c0c-8a64-457f-8319-3f9fdc3a4580