### PR TITLE
BIP-528: Enable 80PAL-20WETH Gauge w 2% Cap [Arbitrum]

### DIFF
--- a/BIPs/2024-W3/BIP-528A.json
+++ b/BIPs/2024-W3/BIP-528A.json
@@ -1,0 +1,40 @@
+{
+  "version": "1.0",
+  "chainId": "1",
+  "createdAt": 1704871780160,
+  "meta": {
+    "name": "Transactions Batch",
+    "description": "Add new gauges",
+    "txBuilderVersion": "1.16.3",
+    "createdFromSafeAddress": "0xc38c5f97B34E175FFd35407fc91a937300E33860",
+    "createdFromOwnerAddress": "",
+    "checksum": ""
+  },
+  "transactions": [
+    {
+      "to": "0x5DbAd78818D4c8958EfF2d5b95b28385A22113Cd",
+      "value": "0",
+      "data": null,
+      "contractMethod": {
+        "inputs": [
+          {
+            "name": "gauge",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "gaugeType",
+            "type": "string",
+            "internalType": "string"
+          }
+        ],
+        "name": "addGauge",
+        "payable": false
+      },
+      "contractInputsValues": {
+        "gauge": "0x2aBd1863C84CdfEA63581D5b4BAb89B690B39DdF",
+        "gaugeType": "Arbitrum"
+      }
+    }
+  ]
+}

--- a/BIPs/2024-W7/BIP-528B.json
+++ b/BIPs/2024-W7/BIP-528B.json
@@ -1,0 +1,40 @@
+{
+  "version": "1.0",
+  "chainId": "1",
+  "createdAt": 1704871989221,
+  "meta": {
+    "name": "Transactions Batch",
+    "description": "Kill obsolete gauges",
+    "txBuilderVersion": "1.16.3",
+    "createdFromSafeAddress": "0x10A19e7eE7d7F8a52822f6817de8ea18204F2e4f",
+    "createdFromOwnerAddress": "",
+    "checksum": ""
+  },
+  "transactions": [
+    {
+      "to": "0xf5dECDB1f3d1ee384908Fbe16D2F0348AE43a9eA",
+      "value": "0",
+      "data": null,
+      "contractMethod": {
+        "inputs": [
+          {
+            "name": "target",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "data",
+            "type": "bytes",
+            "internalType": "bytes"
+          }
+        ],
+        "name": "performAction",
+        "payable": true
+      },
+      "contractInputsValues": {
+        "target": "0xd758454bdf4df7ad85f7538dc9742648ef8e6d0a",
+        "data": "0xab8f0945"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
- BIP-528A: enable new gauge
- Add gauge sim: https://dashboard.tenderly.co/public/safe/safe-apps/simulator/f3debdd3-a42e-4553-8812-82b9d7f95de6
- BIP-528B: kill old gauge
- Kill gauge sim: https://dashboard.tenderly.co/public/safe/safe-apps/simulator/97a20228-db85-417a-a05a-22a4ac578233