### PR TITLE
BIP-541: Enable vETH/wstETH gauge [Ethereum]

### DIFF
--- a/BIPs/2024-W6/BIP-541.json
+++ b/BIPs/2024-W6/BIP-541.json
@@ -1,0 +1,40 @@
+{
+  "version": "1.0",
+  "chainId": "1",
+  "createdAt": 1706720444301,
+  "meta": {
+    "name": "Transactions Batch",
+    "description": "Add new gauges",
+    "txBuilderVersion": "1.16.3",
+    "createdFromSafeAddress": "0xc38c5f97B34E175FFd35407fc91a937300E33860",
+    "createdFromOwnerAddress": "",
+    "checksum": ""
+  },
+  "transactions": [
+    {
+      "to": "0x5DbAd78818D4c8958EfF2d5b95b28385A22113Cd",
+      "value": "0",
+      "data": null,
+      "contractMethod": {
+        "inputs": [
+          {
+            "name": "gauge",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "gaugeType",
+            "type": "string",
+            "internalType": "string"
+          }
+        ],
+        "name": "addGauge",
+        "payable": false
+      },
+      "contractInputsValues": {
+        "gauge": "0x3ca33F22893a51A80Ed4ed8afebc900Ae813cA02",
+        "gaugeType": "Ethereum"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
- enable veETH/wstETH gauge on Mainnet
- Tenderly-sim: https://dashboard.tenderly.co/public/safe/safe-apps/simulator/be8776aa-1fda-4ab0-a1c9-84239b90970b