### PR TITLE
sAVAX-WAVAX: New rewards Schedule

### DIFF
--- a/MaxiOps/injectorScheduling/avax/QI/setRecipientList_avax_sAVAX_QI.json
+++ b/MaxiOps/injectorScheduling/avax/QI/setRecipientList_avax_sAVAX_QI.json
@@ -1,0 +1,46 @@
+{
+  "version": "1.0",
+  "chainId": "43114",
+  "createdAt": 1708589438916,
+  "meta": {
+    "name": "Set new sAVAX QI rewards schedule",
+    "description": "",
+    "txBuilderVersion": "1.16.3",
+    "createdFromSafeAddress": "0x326A7778DB9B741Cb2acA0DE07b9402C7685dAc6",
+    "createdFromOwnerAddress": "",
+    "checksum": "0xb5ffe360573be6bd7f48618b285cccff758ede51f4ea29edd09de81fdbed95e4"
+  },
+  "transactions": [
+    {
+      "to": "0x39C441560e83e02452e4B4789934aC031A85c1d5",
+      "value": "0",
+      "data": null,
+      "contractMethod": {
+        "inputs": [
+          {
+            "name": "gaugeAddresses",
+            "type": "address[]",
+            "internalType": "address[]"
+          },
+          {
+            "name": "amountsPerPeriod",
+            "type": "uint256[]",
+            "internalType": "uint256[]"
+          },
+          {
+            "name": "maxPeriods",
+            "type": "uint8[]",
+            "internalType": "uint8[]"
+          }
+        ],
+        "name": "setRecipientList",
+        "payable": false
+      },
+      "contractInputsValues": {
+        "gaugeAddresses": "[0xf9aE6D2D56f02304f72dcC61694eAD0dC8DB51f7]",
+        "amountsPerPeriod": "[700000000000000000000000]",
+        "maxPeriods": "[4]"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
- Set new Injector schedule on the sAVAX-WAVAX gauge: 700000 QI for 4 weeks
- Tenderly-sim: https://dashboard.tenderly.co/public/safe/safe-apps/simulator/275629af-1bb2-450a-88d0-a81f56fc0b49