### PR TITLE
Raise Aura Vote Incentive min to 1500 USDC

### DIFF
--- a/config/protocol_fees_constants.json
+++ b/config/protocol_fees_constants.json
@@ -1,6 +1,6 @@
 {
-  "min_aura_incentive": 500,
-  "min_existing_aura_incentive": 500,
+  "min_aura_incentive": 1500,
+  "min_existing_aura_incentive": 1500,
   "min_vote_incentive_amount": 500,
   "vebal_share_pct": 0.325,
   "dao_share_pct": 0.175,


### PR DESCRIPTION
Raise mins such that at least 1500 USD is required to place an incentive on the Aura market.

Authorized as per [BIP-457] with the reason that Aura would like us to try to help them reduce gas costs by avoiding small bribes. 

Simulations: https://docs.google.com/spreadsheets/d/1PDFqNzl_38Wprx38VJ-9vEc_1OUPGwjlzVLZSbm3M2s/edit#gid=2142384993