### PR TITLE
BIP-606-wOETH-wETH-Gauge-Arbitrum

### DIFF
--- a/BIPs/2024-W20/BIP-606-wOETH-wETH-Gauge.json
+++ b/BIPs/2024-W20/BIP-606-wOETH-wETH-Gauge.json
@@ -1,0 +1,32 @@
+{
+  "version": "1.0",
+  "chainId": "1",
+  "createdAt": 1715205467820,
+  "meta": {
+    "name": "Transactions Batch",
+    "description": "",
+    "txBuilderVersion": "1.16.5",
+    "createdFromSafeAddress": "0xc38c5f97B34E175FFd35407fc91a937300E33860",
+    "createdFromOwnerAddress": "",
+    "checksum": "0xb1806db12c8a5fb1931c85d64fce6558b2ba928fce9bef1c614279fb56c1086c"
+  },
+  "transactions": [
+    {
+      "to": "0x5DbAd78818D4c8958EfF2d5b95b28385A22113Cd",
+      "value": "0",
+      "data": null,
+      "contractMethod": {
+        "inputs": [
+          { "internalType": "address", "name": "gauge", "type": "address" },
+          { "internalType": "string", "name": "gaugeType", "type": "string" }
+        ],
+        "name": "addGauge",
+        "payable": false
+      },
+      "contractInputsValues": {
+        "gauge": "0x38F1e186cC7609D236AA2161e2ca622B5BC4Ef8b",
+        "gaugeType": "Arbitrum"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
BIP: https://forum.balancer.fi/t/bip-606-enable-woeth-weth-gyro-gauge-w-2-cap-arbitrum/5737

Simulation: https://dashboard.tenderly.co/public/safe/safe-apps/simulator/b5b2db88-d06c-443f-a4ca-a809804e41e5

Specification: The Balancer Maxi LM Multisig eth:0xc38c5f97B34E175FFd35407fc91a937300E33860 will interact with the GaugeAdderv4 at 0x5DbAd78818D4c8958EfF2d5b95b28385A22113Cd and call the addGauge function with the following arguments:

gauge(address): 0x38F1e186cC7609D236AA2161e2ca622B5BC4Ef8b
gaugeType(string): Arbitrum