### PR TITLE
BIP-611-ARB-Delegation

### DIFF
--- a/BIPs/2024-W22/BIP-611-ARB-Delegation.json
+++ b/BIPs/2024-W22/BIP-611-ARB-Delegation.json
@@ -1,0 +1,30 @@
+{
+  "version": "1.0",
+  "chainId": "42161",
+  "createdAt": 1716341508198,
+  "meta": {
+    "name": "Transactions Batch",
+    "description": "",
+    "txBuilderVersion": "1.16.5",
+    "createdFromSafeAddress": "0xaF23DC5983230E9eEAf93280e312e57539D098D0",
+    "createdFromOwnerAddress": "",
+    "checksum": "0x4c73d4d4d12e69bc7010c7657673ff804a6f7ac90e1ee2962192577e03df5bed"
+  },
+  "transactions": [
+    {
+      "to": "0x912CE59144191C1204E64559FE8253a0e49E6548",
+      "value": "0",
+      "data": null,
+      "contractMethod": {
+        "inputs": [
+          { "name": "delegatee", "type": "address", "internalType": "address" }
+        ],
+        "name": "delegate",
+        "payable": false
+      },
+      "contractInputsValues": {
+        "delegatee": "0x583E3EDc26E1B8620341bce90547197bfE2c1ddD"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Forum post: https://forum.balancer.fi/t/bip-xxx-delegate-balancerdao-arb-to-karpatkey/5752

To be executed by Karpatkey; not the Balancer Maxis. Payload for reference and historic purposes.

The Balancer treasury vault managed by karpatkey 0xaf23dc5983230e9eeaf93280e312e57539d098d0 on Arbitrum One will interact with the ARB 0x912CE59144191C1204E64559FE8253a0e49E6548 token contract by calling the delegate function, passing the karpatkey governance multisig 0x583E3EDc26E1B8620341bce90547197bfE2c1ddD as the delegatee.

These actions will delegate the ARB voting power in the Balancer’s Treasury wallet on Arbitrum One to karpatkey’s governance multi-sig.