### PR TITLE
Bridging_USDC_CCTP_Gyro_Rehype_DI

### DIFF
--- a/MaxiOps/05-2024-Misc/USDC_Bridge_Arbitrum_Gyro.json
+++ b/MaxiOps/05-2024-Misc/USDC_Bridge_Arbitrum_Gyro.json
@@ -1,0 +1,61 @@
+{
+  "version": "1.0",
+  "chainId": "1",
+  "createdAt": 1717181212768,
+  "meta": {
+    "name": "Transactions Batch",
+    "description": "",
+    "txBuilderVersion": "1.16.5",
+    "createdFromSafeAddress": "0xc38c5f97B34E175FFd35407fc91a937300E33860",
+    "createdFromOwnerAddress": "",
+    "checksum": "0xb0689e3401da76179e2d61cbbc14512cb4c29b7f092ce99bc8ffd5a1b462642a"
+  },
+  "transactions": [
+    {
+      "to": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+      "value": "0",
+      "data": null,
+      "contractMethod": {
+        "inputs": [
+          { "name": "spender", "type": "address", "internalType": "address" },
+          { "name": "value", "type": "uint256", "internalType": "uint256" }
+        ],
+        "name": "approve",
+        "payable": false
+      },
+      "contractInputsValues": {
+        "spender": "0xBd3fa81B58Ba92a82136038B25aDec7066af3155",
+        "value": "2000000000"
+      }
+    },
+    {
+      "to": "0xBd3fa81B58Ba92a82136038B25aDec7066af3155",
+      "value": "0",
+      "data": null,
+      "contractMethod": {
+        "inputs": [
+          { "name": "amount", "type": "uint256", "internalType": "uint256" },
+          {
+            "name": "destinationDomain",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "mintRecipient",
+            "type": "bytes32",
+            "internalType": "bytes32"
+          },
+          { "name": "burnToken", "type": "address", "internalType": "address" }
+        ],
+        "name": "depositForBurn",
+        "payable": false
+      },
+      "contractInputsValues": {
+        "amount": "2000000000",
+        "destinationDomain": "3",
+        "mintRecipient": "0xc38c5f97B34E175FFd35407fc91a937300E33860",
+        "burnToken": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
+      }
+    }
+  ]
+}

--- a/MaxiOps/05-2024-Misc/USDC_Bridge_Arbitrum_Gyro.report.txt
+++ b/MaxiOps/05-2024-Misc/USDC_Bridge_Arbitrum_Gyro.report.txt
@@ -1,0 +1,33 @@
+FILENAME: `MaxiOps/05-2024-Misc/USDC_Bridge_Arbitrum_Gyro.json`
+MULTISIG: `multisigs/lm (mainnet:0xc38c5f97B34E175FFd35407fc91a937300E33860)`
+COMMIT: `8945694b6b752d09f080a7ba7646c375f20bfbee`
+CHAIN(S): `mainnet`
+TENDERLY: SKIPPED (`Web3ValidationError("\nCould not identify the intended function with name `depositForBurn`, positional arguments with type(s) `int,int,address,address` and keyword arguments with type(s) `{}`.\nFound 1 function(s) with the name `depositForBurn`: ['depositForBurn(uint256,uint32,bytes32,address)']\nFunction invocation failed due to no matching argument types.")`)
+```
++----------------+--------------------------------------------------------------------+-------+--------------------------------------------------------------------------+------------+----------+
+| fx_name        | to                                                                 | value | inputs                                                                   | bip_number | tx_index |
++----------------+--------------------------------------------------------------------+-------+--------------------------------------------------------------------------+------------+----------+
+| approve        | 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48 (tokens/USDC)           | 0     | {                                                                        | N/A        |   N/A    |
+|                |                                                                    |       |   "spender": [                                                           |            |          |
+|                |                                                                    |       |     "0xBd3fa81B58Ba92a82136038B25aDec7066af3155 (circle/cctp_messenger)" |            |          |
+|                |                                                                    |       |   ],                                                                     |            |          |
+|                |                                                                    |       |   "value": [                                                             |            |          |
+|                |                                                                    |       |     "raw:2000000000, 18 decimals:2E-9, 6 decimals: 2000"                 |            |          |
+|                |                                                                    |       |   ]                                                                      |            |          |
+|                |                                                                    |       | }                                                                        |            |          |
+| depositForBurn | 0xBd3fa81B58Ba92a82136038B25aDec7066af3155 (circle/cctp_messenger) | 0     | {                                                                        | N/A        |   N/A    |
+|                |                                                                    |       |   "amount": [                                                            |            |          |
+|                |                                                                    |       |     "raw:2000000000, 18 decimals:2E-9, 6 decimals: 2000"                 |            |          |
+|                |                                                                    |       |   ],                                                                     |            |          |
+|                |                                                                    |       |   "destinationDomain": [                                                 |            |          |
+|                |                                                                    |       |     "3"                                                                  |            |          |
+|                |                                                                    |       |   ],                                                                     |            |          |
+|                |                                                                    |       |   "mintRecipient": [                                                     |            |          |
+|                |                                                                    |       |     "0xc38c5f97B34E175FFd35407fc91a937300E33860 (multisigs/lm)"          |            |          |
+|                |                                                                    |       |   ],                                                                     |            |          |
+|                |                                                                    |       |   "burnToken": [                                                         |            |          |
+|                |                                                                    |       |     "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48 (tokens/USDC)"           |            |          |
+|                |                                                                    |       |   ]                                                                      |            |          |
+|                |                                                                    |       | }                                                                        |            |          |
++----------------+--------------------------------------------------------------------+-------+--------------------------------------------------------------------------+------------+----------+
+```


### PR DESCRIPTION
Direct incentives of 2000 USDC to be used for 1 week on Gyro rehype pools:  There are three pools
- Connector pools for USDC/AaveUSDCn and USDT/AaveUSDT
- The main Rehype pool AaveUSDCn/AaveUSDT

- 280 on USDC/AaveUSDCn
- 280 on USDT/AaveUSDT
- 1440 on AaveUSDCn/AaveUSDT

CCTP destinationDomains https://developers.circle.com/stablecoins/docs/evm-smart-contracts