### PR TITLE
lower min_aura_incentive to 1000

### DIFF
--- a/config/protocol_fees_constants.json
+++ b/config/protocol_fees_constants.json
@@ -1,5 +1,5 @@
 {
-  "min_aura_incentive": 1500,
+  "min_aura_incentive": 1000,
   "min_existing_aura_incentive": 1500,
   "min_vote_incentive_amount": 500,
   "vebal_share_pct": 0.325,


### PR DESCRIPTION
Try to get a bit better aura distro on L2s.

See Aura BD chat for convo with Maha.  TL;DR We're ok like at 1000 until fees/gas pick up substantially. 