### PR TITLE
chore: migrate injector arb1

### DIFF
--- a/MaxiOps/chainlinkAutomation/migrate_injector_arb1_part1.json
+++ b/MaxiOps/chainlinkAutomation/migrate_injector_arb1_part1.json
@@ -1,0 +1,49 @@
+{
+  "version": "1.0",
+  "chainId": "42161",
+  "createdAt": 1718210246681,
+  "meta": {
+    "name": "Transactions Batch",
+    "description": "",
+    "txBuilderVersion": "1.16.5",
+    "createdFromSafeAddress": "0xb6BfF54589f269E248f99D5956f1fDD5b014D50e",
+    "createdFromOwnerAddress": "",
+    "checksum": "0x5eaa35980ffba8f091e95ef94993a9e825bb88198dde0b27681c263777360de5"
+  },
+  "transactions": [
+    {
+      "to": "0xF23d8342881eDECcED51EA694AC21C2B68440929",
+      "value": "0",
+      "data": null,
+      "contractMethod": {
+        "inputs": [
+          {
+            "name": "keeperRegistryAddress",
+            "type": "address",
+            "internalType": "address"
+          }
+        ],
+        "name": "setKeeperRegistryAddress",
+        "payable": false
+      },
+      "contractInputsValues": {
+        "keeperRegistryAddress": "0x9465eD2edD1428CF7d1151f6376ba2C7dfcda466"
+      }
+    },
+    {
+      "to": "0xF23d8342881eDECcED51EA694AC21C2B68440929",
+      "value": "0",
+      "data": null,
+      "contractMethod": {
+        "inputs": [
+          { "name": "to", "type": "address", "internalType": "address" }
+        ],
+        "name": "transferOwnership",
+        "payable": false
+      },
+      "contractInputsValues": {
+        "to": "0x9ff471F9f98F42E5151C7855fD1b5aa906b1AF7e"
+      }
+    }
+  ]
+}

--- a/MaxiOps/chainlinkAutomation/migrate_injector_arb1_part1.report.txt
+++ b/MaxiOps/chainlinkAutomation/migrate_injector_arb1_part1.report.txt
@@ -1,8 +1,8 @@
 FILENAME: `MaxiOps/chainlinkAutomation/migrate_injector_arb1_part1.json`
 MULTISIG: `multisigs/kyc_grant_safe (arbitrum:0xb6BfF54589f269E248f99D5956f1fDD5b014D50e)`
-COMMIT: `9b1b5c5c740858e7ce28474faf4117908e86c2a4`
+COMMIT: `4c237084451e93ff15dd5e3372b71b063cf1ccde`
 CHAIN(S): `arbitrum`
-TENDERLY: [SUCCESS](https://www.tdly.co/shared/simulation/559302e9-3c2a-44ec-a1ed-e0c2632124a9)
+TENDERLY: [SUCCESS](https://www.tdly.co/shared/simulation/a43e06ef-7fa4-4c97-8278-97ef55c035cb)
 ```
 +--------------------------+--------------------------------------------------------------------------------------------------+-------+---------------------------------------------------------------------------------------+------------+----------+
 | fx_name                  | to                                                                                               | value | inputs                                                                                | bip_number | tx_index |

--- a/MaxiOps/chainlinkAutomation/migrate_injector_arb1_part1.report.txt
+++ b/MaxiOps/chainlinkAutomation/migrate_injector_arb1_part1.report.txt
@@ -1,0 +1,21 @@
+FILENAME: `MaxiOps/chainlinkAutomation/migrate_injector_arb1_part1.json`
+MULTISIG: `multisigs/kyc_grant_safe (arbitrum:0xb6BfF54589f269E248f99D5956f1fDD5b014D50e)`
+COMMIT: `9b1b5c5c740858e7ce28474faf4117908e86c2a4`
+CHAIN(S): `arbitrum`
+TENDERLY: [SUCCESS](https://www.tdly.co/shared/simulation/559302e9-3c2a-44ec-a1ed-e0c2632124a9)
+```
++--------------------------+--------------------------------------------------------------------------------------------------+-------+---------------------------------------------------------------------------------------+------------+----------+
+| fx_name                  | to                                                                                               | value | inputs                                                                                | bip_number | tx_index |
++--------------------------+--------------------------------------------------------------------------------------------------+-------+---------------------------------------------------------------------------------------+------------+----------+
+| setKeeperRegistryAddress | 0xF23d8342881eDECcED51EA694AC21C2B68440929 (maxiKeepers/gaugeRewardsInjectors/arb_STIP_injector) | 0     | {                                                                                     | N/A        |   N/A    |
+|                          |                                                                                                  |       |   "keeperRegistryAddress": [                                                          |            |          |
+|                          |                                                                                                  |       |     "0x9465eD2edD1428CF7d1151f6376ba2C7dfcda466 (N/A)"                                |            |          |
+|                          |                                                                                                  |       |   ]                                                                                   |            |          |
+|                          |                                                                                                  |       | }                                                                                     |            |          |
+| transferOwnership        | 0xF23d8342881eDECcED51EA694AC21C2B68440929 (maxiKeepers/gaugeRewardsInjectors/arb_STIP_injector) | 0     | {                                                                                     | N/A        |   N/A    |
+|                          |                                                                                                  |       |   "to": [                                                                             |            |          |
+|                          |                                                                                                  |       |     "0x9ff471F9f98F42E5151C7855fD1b5aa906b1AF7e (multisigs/vote_incentive_recycling)" |            |          |
+|                          |                                                                                                  |       |   ]                                                                                   |            |          |
+|                          |                                                                                                  |       | }                                                                                     |            |          |
++--------------------------+--------------------------------------------------------------------------------------------------+-------+---------------------------------------------------------------------------------------+------------+----------+
+```

--- a/MaxiOps/chainlinkAutomation/migrate_injector_arb1_part2.json
+++ b/MaxiOps/chainlinkAutomation/migrate_injector_arb1_part2.json
@@ -1,0 +1,26 @@
+{
+  "version": "1.0",
+  "chainId": "1",
+  "createdAt": 1718210405132,
+  "meta": {
+    "name": "Transactions Batch",
+    "description": "",
+    "txBuilderVersion": "1.16.5",
+    "createdFromSafeAddress": "0x9ff471F9f98F42E5151C7855fD1b5aa906b1AF7e",
+    "createdFromOwnerAddress": "",
+    "checksum": "0x92a14c7c8a998fd771ce54b457f8bf7c9ee5f77ce5ae86e88e02193fec2f31bb"
+  },
+  "transactions": [
+    {
+      "to": "0xF23d8342881eDECcED51EA694AC21C2B68440929",
+      "value": "0",
+      "data": null,
+      "contractMethod": {
+        "inputs": [],
+        "name": "acceptOwnership",
+        "payable": false
+      },
+      "contractInputsValues": null
+    }
+  ]
+}

--- a/MaxiOps/chainlinkAutomation/migrate_injector_arb1_part2.json
+++ b/MaxiOps/chainlinkAutomation/migrate_injector_arb1_part2.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0",
-  "chainId": "1",
+  "chainId": "42161",
   "createdAt": 1718210405132,
   "meta": {
     "name": "Transactions Batch",

--- a/MaxiOps/chainlinkAutomation/migrate_injector_arb1_part2.report.txt
+++ b/MaxiOps/chainlinkAutomation/migrate_injector_arb1_part2.report.txt
@@ -1,0 +1,12 @@
+FILENAME: `MaxiOps/chainlinkAutomation/migrate_injector_arb1_part2.json`
+MULTISIG: `multisigs/vote_incentive_recycling (mainnet:0x9ff471F9f98F42E5151C7855fD1b5aa906b1AF7e)`
+COMMIT: `9b1b5c5c740858e7ce28474faf4117908e86c2a4`
+CHAIN(S): `mainnet`
+TENDERLY: [FAILURE](https://www.tdly.co/shared/simulation/2794db43-7657-4923-8c83-6324f34da6ee)
+```
++-----------------+--------------------------------------------------------+-------+--------+------------+----------+
+| fx_name         | to                                                     | value | inputs | bip_number | tx_index |
++-----------------+--------------------------------------------------------+-------+--------+------------+----------+
+| acceptOwnership | 0xF23d8342881eDECcED51EA694AC21C2B68440929 (Not Found) | 0     | "N/A"  | N/A        |   N/A    |
++-----------------+--------------------------------------------------------+-------+--------+------------+----------+
+```

--- a/MaxiOps/chainlinkAutomation/migrate_injector_arb1_part2.report.txt
+++ b/MaxiOps/chainlinkAutomation/migrate_injector_arb1_part2.report.txt
@@ -1,12 +1,12 @@
 FILENAME: `MaxiOps/chainlinkAutomation/migrate_injector_arb1_part2.json`
-MULTISIG: `multisigs/vote_incentive_recycling (mainnet:0x9ff471F9f98F42E5151C7855fD1b5aa906b1AF7e)`
-COMMIT: `9b1b5c5c740858e7ce28474faf4117908e86c2a4`
-CHAIN(S): `mainnet`
-TENDERLY: [FAILURE](https://www.tdly.co/shared/simulation/2794db43-7657-4923-8c83-6324f34da6ee)
+MULTISIG: `multisigs/vote_incentive_recycling (arbitrum:0x9ff471F9f98F42E5151C7855fD1b5aa906b1AF7e)`
+COMMIT: `4c237084451e93ff15dd5e3372b71b063cf1ccde`
+CHAIN(S): `arbitrum`
+TENDERLY: [FAILURE](https://www.tdly.co/shared/simulation/8a64619a-1806-4bb7-a17f-28329d1b8f45)
 ```
-+-----------------+--------------------------------------------------------+-------+--------+------------+----------+
-| fx_name         | to                                                     | value | inputs | bip_number | tx_index |
-+-----------------+--------------------------------------------------------+-------+--------+------------+----------+
-| acceptOwnership | 0xF23d8342881eDECcED51EA694AC21C2B68440929 (Not Found) | 0     | "N/A"  | N/A        |   N/A    |
-+-----------------+--------------------------------------------------------+-------+--------+------------+----------+
++-----------------+--------------------------------------------------------------------------------------------------+-------+--------+------------+----------+
+| fx_name         | to                                                                                               | value | inputs | bip_number | tx_index |
++-----------------+--------------------------------------------------------------------------------------------------+-------+--------+------------+----------+
+| acceptOwnership | 0xF23d8342881eDECcED51EA694AC21C2B68440929 (maxiKeepers/gaugeRewardsInjectors/arb_STIP_injector) | 0     | "N/A"  | N/A        |   N/A    |
++-----------------+--------------------------------------------------------------------------------------------------+-------+--------+------------+----------+
 ```


### PR DESCRIPTION
- part 1 (kyc msig):
  - whitelists the new forwarder (see https://automation.chain.link/arbitrum/32362394734451035504199802047588354855838202363897445238253548040898877967375) as the 'keeper registry'
  - transfer ownership on the injector to the lm omnichain msig
- part 2 (lm omni msig):
  - accept ownership of the injector

part 2 will fail in sim until part 1 has been execd onchain