### PR TITLE
[BIP-643] Enable BAO 8020 Gauges [Ethereum]

### DIFF
--- a/BIPs/2024-W27/BIP-643 Enable BAO 8020 Gauges.json
+++ b/BIPs/2024-W27/BIP-643 Enable BAO 8020 Gauges.json
@@ -1,0 +1,49 @@
+{
+  "version": "1.0",
+  "chainId": "1",
+  "createdAt": 1719437001163,
+  "meta": {
+    "name": "Transactions Batch",
+    "description": "",
+    "txBuilderVersion": "1.16.5",
+    "createdFromSafeAddress": "0xc38c5f97B34E175FFd35407fc91a937300E33860",
+    "createdFromOwnerAddress": "",
+    "checksum": "0xad5a8838bf7e39e30e59ee1465f8c4173f3343e8f6a97199708e18d8fdf68682"
+  },
+  "transactions": [
+    {
+      "to": "0x5DbAd78818D4c8958EfF2d5b95b28385A22113Cd",
+      "value": "0",
+      "data": null,
+      "contractMethod": {
+        "inputs": [
+          { "internalType": "address", "name": "gauge", "type": "address" },
+          { "internalType": "string", "name": "gaugeType", "type": "string" }
+        ],
+        "name": "addGauge",
+        "payable": false
+      },
+      "contractInputsValues": {
+        "gauge": "0x6b9dE817875952Cb23d985AbF6fa9ec4b7f66ad5",
+        "gaugeType": "Ethereum"
+      }
+    },
+    {
+      "to": "0x5DbAd78818D4c8958EfF2d5b95b28385A22113Cd",
+      "value": "0",
+      "data": null,
+      "contractMethod": {
+        "inputs": [
+          { "internalType": "address", "name": "gauge", "type": "address" },
+          { "internalType": "string", "name": "gaugeType", "type": "string" }
+        ],
+        "name": "addGauge",
+        "payable": false
+      },
+      "contractInputsValues": {
+        "gauge": "0x7C02ac2BAd481dC4E566D3D54359244f381d58dC",
+        "gaugeType": "Ethereum"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Enable BAO 8020 Gauges, BAO is paired with baoUSD/LUSD and baoETH/wETH pools. No rate providers. Proposal: https://forum.balancer.fi/t/bip-xxx-enable-gauges-for-bao-baousd-lusd-80-20-and-bao-baoeth-eth-80-20-w-2-cap-ethereum/5820