### PR TITLE
Reduce min aura vote to 800 for better handling on L2s and STIP action

### DIFF
--- a/config/protocol_fees_constants.json
+++ b/config/protocol_fees_constants.json
@@ -1,6 +1,6 @@
 {
   "min_aura_incentive": 1000,
-  "min_existing_aura_incentive": 1500,
+  "min_existing_aura_incentive": 800,
   "min_vote_incentive_amount": 500,
   "vebal_share_pct": 0.325,
   "dao_share_pct": 0.175,


### PR DESCRIPTION
Spoke to @Xeonus about this.  Need min 40k aura for a vote, this should be more than enough.

Right now almost all the aura voting is going ot 1 pool on the L2s, and in some cases there is nowhere for it to go.

Dropping down to 800 should allow a lot more pools to get Aura votes on L2s, and will enable the whole STIP flywheel to work better/spin up smaller pools. 