### PR TITLE
HH-Bribe-Refunds-June&July-2024

### DIFF
--- a/MaxiOps/brib_rebate_handling/06-2024/Bribe_Refund_June2024.md
+++ b/MaxiOps/brib_rebate_handling/06-2024/Bribe_Refund_June2024.md
@@ -1,0 +1,23 @@
+# Bribe rebates 
+
+Bribe rebates will be 3% of the total amount of tokens Balancer sends specifically to Hidden Hand during each month. For example in this txn: https://etherscan.io/tx/0xff71dd036a7db0c9289722bd62b22bb9ac55cc12774571e8f5f03db5b719486c the total amount sent by the Balancer: Protocol Fees Multisig was 327,937.028191 USDC, however the net transfer to the Hidden Hand contract was 163,968.549999 USDC which is what the refund would be based on. 
+
+### Asking for rebates    
+
+The current process for requesting rebates is the collect the transactions from a given month from the [Protocol Fees Multisig](https://etherscan.io/address/0x7c68c42de679ffb0f16216154c996c354cf1161b) contract address on etherscan. Once the Maxis have the transactions they will totalize the amount send to [Hidden hand's contract address](https://etherscan.io/address/0xe00fe722e5be7ad45b1a16066e431e47df476cec#readContract) and share the transaction links, totaly bribe amount, and refund amount (bribes * 0.03) for the given month.
+
+### Update for Round dated June 8th 2024
+
+Transaction: https://etherscan.io/tx/0x16aed919b90b152dedbc2a3871893cf88b13b31d24b73d05d768303a2fd795e8
+
+Net Transfer to HH: 229,119.20479 - 3% of Transfer: 6,873.57
+
+### Final amount for June 2024 after June 21st round.
+
+Transaction: https://etherscan.io/tx/0x846c3ef2b5fff0878cdfe52aa5cb7e99c0d5b0d1af16cffd02c8320b7e29c859
+
+Net Transfer to HH: 247,606.304199 - 3% of Transfer: 7,428.19
+
+Rolling bribe refund: 6,873.57 + 7,428.19 = 14,302.76
+
+*Total bribe refund for June 2024: 14,302.76 USDC*

--- a/MaxiOps/brib_rebate_handling/07-2024/Bribe_Refund_July2024.md
+++ b/MaxiOps/brib_rebate_handling/07-2024/Bribe_Refund_July2024.md
@@ -1,0 +1,23 @@
+# Bribe rebates 
+
+Bribe rebates will be 3% of the total amount of tokens Balancer sends specifically to Hidden Hand during each month. For example in this txn: https://etherscan.io/tx/0xff71dd036a7db0c9289722bd62b22bb9ac55cc12774571e8f5f03db5b719486c the total amount sent by the Balancer: Protocol Fees Multisig was 327,937.028191 USDC, however the net transfer to the Hidden Hand contract was 163,968.549999 USDC which is what the refund would be based on. 
+
+### Asking for rebates    
+
+The current process for requesting rebates is the collect the transactions from a given month from the [Protocol Fees Multisig](https://etherscan.io/address/0x7c68c42de679ffb0f16216154c996c354cf1161b) contract address on etherscan. Once the Maxis have the transactions they will totalize the amount send to [Hidden hand's contract address](https://etherscan.io/address/0xe00fe722e5be7ad45b1a16066e431e47df476cec#readContract) and share the transaction links, totaly bribe amount, and refund amount (bribes * 0.03) for the given month.
+
+### Update for Round dated July 5th 2024
+
+Transaction: https://etherscan.io/tx/0x4aa385412e3330994bc5891b20800bdba99cdcf16c899e2d8fe17facd9808494
+
+Net Transfer to HH: 267,940.346096 - 3% of Transfer: 8,038.21
+
+### Final amount for July 2024 after July 19th round.
+
+Transaction: https://etherscan.io/tx/0x1381528040b284d776577ed1a5dce0c2116eb6bd67da186443a4955639a5abaa
+
+Net Transfer to HH: 171,216.449598 - 3% of Transfer: 5,136.49
+
+Rolling bribe refund: 8,038.21 + 5,136.49 = 13,174.70
+
+*Total bribe refund for July 2024: 13,174.70 USDC*


### PR DESCRIPTION
Includes previous four fee rounds, two per month resulting in:

*Total bribe refund for July 2024: 13,174.70 USDC*  + *Total bribe refund for June 2024: 14,302.76 USDC* for a total amount across two months equal to 27,477.46 USDC.