### PR TITLE
automatically post votes on merged vote csv

### DIFF
--- a/.github/workflows/post_aura_gauge_votes.yaml
+++ b/.github/workflows/post_aura_gauge_votes.yaml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
     paths:
-      - 'MaxiOps/vlaura_voting/**/*.csv'
+      - 'MaxiOps/vlaura_voting/**/input/*.csv'
 
 jobs:
   post_aura_gauge_votes:
@@ -26,7 +26,7 @@ jobs:
       id: week-string
       run: |
         # Get the path of the changed CSV file
-        CSV_PATH=$(git diff --name-only ${{ github.event.before }} ${{ github.sha }} | grep '\.csv$' | head -n 1)
+        CSV_PATH=$(git diff --name-only ${{ github.event.before }} ${{ github.sha }} | grep '/input/.*\.csv$' | head -n 1)
         
         if [ -z "$CSV_PATH" ]; then
           echo "No CSV file found in recent changes."

--- a/.github/workflows/post_aura_gauge_votes.yaml
+++ b/.github/workflows/post_aura_gauge_votes.yaml
@@ -1,24 +1,45 @@
 name: Post vlAURA snapshot votes to voter multisig and send to the vote relayer
 
 on:
-  workflow_dispatch:
-    inputs:
-      week-string:
-        description: 'Week string that votes are are being posted. should be YYYY-W##'
-        required: true
+  push:
+    branches:
+      - main
+    paths:
+      - 'MaxiOps/vlaura_voting/**/*.csv'
 
 jobs:
-  post_aura_guage_votes:
+  post_aura_gauge_votes:
     runs-on: ubuntu-latest
 
     steps:
     - name: Checkout
       uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
 
     - name: Setup Python 3.9
       uses: actions/setup-python@v5
       with:
         python-version: 3.9
+
+    - name: Determine week-string
+      id: week-string
+      run: |
+        # Get the path of the changed CSV file
+        CSV_PATH=$(git diff --name-only ${{ github.event.before }} ${{ github.sha }} | grep '\.csv$' | head -n 1)
+        
+        if [ -z "$CSV_PATH" ]; then
+          echo "No CSV file found in recent changes."
+          exit 1
+        fi
+
+        echo "CSV Path: $CSV_PATH"
+        
+        YEAR=$(echo $CSV_PATH | cut -d'/' -f3)
+        WEEK=$(echo $CSV_PATH | cut -d'/' -f4)
+        WEEK_STRING="${YEAR}-${WEEK}"
+
+        echo "week-string=$WEEK_STRING" >> $GITHUB_OUTPUT
 
     - name: vlAURA Voting
       env:
@@ -28,13 +49,15 @@ jobs:
         pwd
         RUN_DIR=tools/python/aura_snapshot_voting
         pip3 install -r $RUN_DIR/requirements.txt
-        python3 $RUN_DIR/vote.py --week-string "${{ github.event.inputs.week-string }}"
+        echo "grabbing votes for: ${{ steps.week-string.outputs.week-string }}"
+        python3 $RUN_DIR/vote.py --week-string "${{ steps.week-string.outputs.week-string }}"
+
     - name: Create PR
       id: cpr
       uses: peter-evans/create-pull-request@v6
       with:
-        commit-message: "task: vlaura vote report for ${{ github.event.inputs.week-string }}"
-        title: "vlaura vote report for ${{ github.event.inputs.week-string }}"
-        branch: "gha-biweekly-vlaura-votes-${{ github.event.inputs.week-string }}"
+        commit-message: "task: vlaura vote report for ${{ steps.week-string.outputs.week-string }}"
+        title: "vlaura vote report for ${{ steps.week-string.outputs.week-string }}"
+        branch: "gha-biweekly-vlaura-votes-${{ steps.week-string.outputs.week-string }}"
         delete-branch: true
         labels: "vlAURA-Voting-Round"


### PR DESCRIPTION
final automation step for #685, works by retrieving the path of csvs merged into any `input` folder in `'MaxiOps/vlaura_voting/`, parses the year/week from the path, then passes it into the voting script.

tested on fork:
[csv vote pr](https://github.com/jalbrekt85/multisig-ops/pull/24)
[action being automatically run](https://github.com/jalbrekt85/multisig-ops/actions/runs/10164789709)