### PR TITLE
Always pay at least 800 to Aura markets.

### DIFF
--- a/config/protocol_fees_constants.json
+++ b/config/protocol_fees_constants.json
@@ -1,7 +1,7 @@
 {
   "min_aura_incentive": 1000,
-  "min_existing_aura_incentive": 800,
-  "min_vote_incentive_amount": 500,
+  "min_existing_aura_incentive": 600,
+  "min_vote_incentive_amount": 800,
   "vebal_share_pct": 0.325,
   "dao_share_pct": 0.175,
   "vote_incentive_pct": 0.5


### PR DESCRIPTION
Last round 768 USD DFX incentives resulted in 0.12% of the vlAURA vote.  Need 0.1 to not be filtered.  This should be safe for a little while.

Also do not redistribute aura if the pool alerady has at least 600 bucks in Aura incentives from other sources posted at the time of allocation.