### PR TITLE
Set proper caps for protocol_fee_allocator

### DIFF
--- a/config/protocol_fees_constants.json
+++ b/config/protocol_fees_constants.json
@@ -1,7 +1,7 @@
 {
-  "min_aura_incentive": 1000,
+  "min_aura_incentive": 800,
   "min_existing_aura_incentive": 600,
-  "min_vote_incentive_amount": 800,
+  "min_vote_incentive_amount": 500,
   "vebal_share_pct": 0.325,
   "dao_share_pct": 0.175,
   "vote_incentive_pct": 0.5


### PR DESCRIPTION
800 min aura unless 600 is already in place
at least 500 bucks for a brib

Last PR mixed up min_vote_incentive and min_aura