### PR TITLE
ci: run internal and external prs in different envs

### DIFF
--- a/.github/workflows/process_every_payload.yaml
+++ b/.github/workflows/process_every_payload.yaml
@@ -1,7 +1,7 @@
 name: Process BIP PR
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, reopened, synchronize]
     paths:
       - "BIPs/**"

--- a/.github/workflows/run_reports_reusable.yaml
+++ b/.github/workflows/run_reports_reusable.yaml
@@ -13,6 +13,7 @@ on:
 jobs:
   generate_reports:
     runs-on: ubuntu-latest
+    environment: ${{ github.event.pull_request.head.repo.full_name != github.repository && 'external' || 'internal' }}
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       WEB3_INFURA_PROJECT_ID: ${{ secrets.WEB3_INFURA_PROJECT_ID }}


### PR DESCRIPTION
closes #1237 

merging this to `main` will require that going forward this repo has two environments defined: `internal` and `external`. the `external` one will need a protection rule set up of "required reviewers":

<img width="364" alt="Screenshot 2024-08-19 at 18 52 31" src="https://github.com/user-attachments/assets/dcea8ef7-2a0b-45f1-be86-d25943e86e5f">
