### PR TITLE
ci: leverage fork var instead of repo names

### DIFF
--- a/.github/workflows/run_reports_reusable.yaml
+++ b/.github/workflows/run_reports_reusable.yaml
@@ -13,7 +13,7 @@ on:
 jobs:
   generate_reports:
     runs-on: ubuntu-latest
-    environment: ${{ github.event.pull_request.head.repo.full_name != github.repository && 'external' || 'internal' }}
+    environment: ${{ github.event.pull_request.head.repo.fork && 'external' || 'internal' }}
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       WEB3_INFURA_PROJECT_ID: ${{ secrets.WEB3_INFURA_PROJECT_ID }}

--- a/.gitignore
+++ b/.gitignore
@@ -144,3 +144,6 @@ dmypy.json
 
 # Pipenv
 Pipfile*
+
+# nektos/act
+.actrc


### PR DESCRIPTION
this should solve the issue of prs opened by actions instead of actual users to be recognised as external prs