### PR TITLE
validate vlaura vote csv

### DIFF
--- a/.github/workflows/review_aura_gauge_votes.yaml
+++ b/.github/workflows/review_aura_gauge_votes.yaml
@@ -1,0 +1,61 @@
+name: Review vLAURA Votes
+
+on:
+  pull_request:
+    paths:
+      - 'MaxiOps/vlaura_voting/**/input/*.csv'
+
+jobs:
+  review_votes:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - name: Setup Python 3.9
+      uses: actions/setup-python@v5
+      with:
+        python-version: 3.9
+
+    - name: Determine week-string
+      id: week-string
+      run: |
+        # Get the path of the changed CSV file
+        CSV_PATH=$(git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} | grep '/input/.*\.csv$' | head -n 1)
+        
+        if [ -z "$CSV_PATH" ]; then
+          echo "No CSV file found in recent changes."
+          exit 1
+        fi
+
+        echo "CSV Path: $CSV_PATH"
+        
+        YEAR=$(echo $CSV_PATH | cut -d'/' -f3)
+        WEEK=$(echo $CSV_PATH | cut -d'/' -f4)
+        WEEK_STRING="${YEAR}-${WEEK}"
+
+        echo "week-string=$WEEK_STRING" >> $GITHUB_OUTPUT
+
+    - name: Review vLAURA Votes
+      run: |
+        pwd
+        RUN_DIR=tools/python/aura_snapshot_voting
+        pip3 install -r $RUN_DIR/requirements.txt
+        echo "Reviewing votes for: ${{ steps.week-string.outputs.week-string }}"
+        python3 $RUN_DIR/review_votes.py --week-string "${{ steps.week-string.outputs.week-string }}"
+
+    - name: Comment PR
+      uses: actions/github-script@v6
+      with:
+        github-token: ${{secrets.GITHUB_TOKEN}}
+        script: |
+          const fs = require('fs');
+          const reviewOutput = fs.readFileSync('review_output.md', 'utf8');
+          github.rest.issues.createComment({
+            issue_number: context.issue.number,
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            body: reviewOutput
+          });

--- a/tools/python/aura_snapshot_voting/requirements.txt
+++ b/tools/python/aura_snapshot_voting/requirements.txt
@@ -10,3 +10,4 @@ dataclasses-json
 python-dotenv
 pytest
 eth-account
+tabulate

--- a/tools/python/aura_snapshot_voting/review_votes.py
+++ b/tools/python/aura_snapshot_voting/review_votes.py
@@ -1,0 +1,87 @@
+import pandas as pd
+import glob
+import os
+import argparse
+from pathlib import Path
+from bal_addresses.utils import to_checksum_address
+import requests
+
+def find_project_root(current_path=None):
+    anchor_file = "multisigs.md"
+    if current_path is None:
+        current_path = Path(__file__).resolve().parent
+    if (current_path / anchor_file).exists():
+        return current_path
+    parent = current_path.parent
+    if parent == current_path:
+        raise FileNotFoundError("Project root not found")
+    return find_project_root(parent)
+
+def fetch_gauge_labels():
+    GAUGE_MAPPING_URL = "https://raw.githubusercontent.com/aurafinance/aura-contracts/main/tasks/snapshot/gauge_choices.json"
+    response = requests.get(GAUGE_MAPPING_URL)
+    response.raise_for_status()
+    gauge_data = response.json()
+    return {to_checksum_address(x["address"]): x["label"] for x in gauge_data}
+
+def review_votes(week_string):
+    year, week = week_string.split("-")
+    project_root = find_project_root()
+    base_path = project_root / "MaxiOps/vlaura_voting"
+    voting_dir = base_path / str(year) / str(week)
+    input_dir = voting_dir / "input"
+    
+    csv_files = glob.glob(str(input_dir / "*.csv"))
+    if not csv_files:
+        return "No CSV files found in the input directory."
+
+    csv_file = csv_files[0]
+    vote_df = pd.read_csv(csv_file)
+    
+    vote_df = vote_df.dropna(subset=["Gauge Address", "Label", "Allocation %"])
+    
+    gauge_labels = fetch_gauge_labels()
+    
+    vote_df["Checksum Address"] = vote_df["Gauge Address"].apply(lambda x: to_checksum_address(x.strip()))
+    vote_df["Snapshot Label"] = vote_df["Checksum Address"].map(gauge_labels)
+    missing_labels = vote_df[vote_df["Snapshot Label"].isna()]
+    snapshot_label_check = len(missing_labels) == 0
+    
+    total_allocation = vote_df["Allocation %"].str.rstrip("%").astype(float).sum()
+    allocation_check = abs(total_allocation - 100) < 0.0001
+    
+    report = f"""## vLAURA Votes Review
+
+CSV file: `{os.path.relpath(csv_file, project_root)}`
+
+### Allocation Check
+- Total allocation: {total_allocation:.2f}%
+- Passes 100% check: {"✅" if allocation_check else "❌"}
+
+### Snapshot Votes Check
+- All gauge addresses have corresponding snapshot choices: {"✅" if snapshot_label_check else "❌"}
+{f"- Missing labels for {len(missing_labels)} gauge(s):" if not snapshot_label_check else ""}
+{missing_labels[["Chain", "Label", "Gauge Address"]].to_string(index=False) if not snapshot_label_check else ""}
+
+### Vote Summary
+
+{vote_df[["Chain", "Label", "Gauge Address", "Allocation %"]].to_markdown(index=False)}
+
+{"### ✅ All checks passed" if (allocation_check and snapshot_label_check) else "### ❌ Some checks failed"}
+    """
+    
+    with open("review_output.md", "w") as f:
+        f.write(report)
+    
+    return report
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Vote review script")
+    parser.add_argument(
+        "--week-string",
+        type=str,
+        required=True,
+        help="Date that votes are being reviewed. Should be YYYY-W##",
+    )
+    args = parser.parse_args()
+    review_votes(args.week_string)

--- a/tools/python/aura_snapshot_voting/review_votes.py
+++ b/tools/python/aura_snapshot_voting/review_votes.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from bal_addresses.utils import to_checksum_address
 import requests
 
+
 def find_project_root(current_path=None):
     anchor_file = "multisigs.md"
     if current_path is None:
@@ -17,6 +18,7 @@ def find_project_root(current_path=None):
         raise FileNotFoundError("Project root not found")
     return find_project_root(parent)
 
+
 def fetch_gauge_labels():
     GAUGE_MAPPING_URL = "https://raw.githubusercontent.com/aurafinance/aura-contracts/main/tasks/snapshot/gauge_choices.json"
     response = requests.get(GAUGE_MAPPING_URL)
@@ -24,32 +26,35 @@ def fetch_gauge_labels():
     gauge_data = response.json()
     return {to_checksum_address(x["address"]): x["label"] for x in gauge_data}
 
+
 def review_votes(week_string):
     year, week = week_string.split("-")
     project_root = find_project_root()
     base_path = project_root / "MaxiOps/vlaura_voting"
     voting_dir = base_path / str(year) / str(week)
     input_dir = voting_dir / "input"
-    
+
     csv_files = glob.glob(str(input_dir / "*.csv"))
     if not csv_files:
         return "No CSV files found in the input directory."
 
     csv_file = csv_files[0]
     vote_df = pd.read_csv(csv_file)
-    
+
     vote_df = vote_df.dropna(subset=["Gauge Address", "Label", "Allocation %"])
-    
+
     gauge_labels = fetch_gauge_labels()
-    
-    vote_df["Checksum Address"] = vote_df["Gauge Address"].apply(lambda x: to_checksum_address(x.strip()))
+
+    vote_df["Checksum Address"] = vote_df["Gauge Address"].apply(
+        lambda x: to_checksum_address(x.strip())
+    )
     vote_df["Snapshot Label"] = vote_df["Checksum Address"].map(gauge_labels)
     missing_labels = vote_df[vote_df["Snapshot Label"].isna()]
     snapshot_label_check = len(missing_labels) == 0
-    
+
     total_allocation = vote_df["Allocation %"].str.rstrip("%").astype(float).sum()
     allocation_check = abs(total_allocation - 100) < 0.0001
-    
+
     report = f"""## vLAURA Votes Review
 
 CSV file: `{os.path.relpath(csv_file, project_root)}`
@@ -69,11 +74,12 @@ CSV file: `{os.path.relpath(csv_file, project_root)}`
 
 {"### ✅ All checks passed" if (allocation_check and snapshot_label_check) else "### ❌ Some checks failed"}
     """
-    
+
     with open("review_output.md", "w") as f:
         f.write(report)
-    
+
     return report
+
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Vote review script")


### PR DESCRIPTION
the workflow creates a report comment on a pr that is triggered when a csv is commited into `MaxiOps/vlaura_voting/**/input/*.csv`

checks that the allocation adds up to 100% and that each gauge address has a corresponding snapshot vote choice

see [here](https://github.com/jalbrekt85/multisig-ops/pull/34#issuecomment-2313343487) for an example of what the report comment looks like