### PR TITLE
AAVE_ARB_Injection-9-9-2024-to-9-20-2024

### DIFF
--- a/MaxiOps/00partnerLM/TokenLogic/ARB/GHO-2024-09-09.json
+++ b/MaxiOps/00partnerLM/TokenLogic/ARB/GHO-2024-09-09.json
@@ -1,0 +1,42 @@
+{
+  "version": "1.0",
+  "chainId": "42161",
+  "createdAt": 1722608476993,
+  "meta": {
+    "name": "Transactions Batch",
+    "description": "",
+    "txBuilderVersion": "1.16.5",
+    "createdFromSafeAddress": "0x9ff471F9f98F42E5151C7855fD1b5aa906b1AF7e",
+    "createdFromOwnerAddress": "",
+    "checksum": "0x21a8725f6a00ae907f9375550ab89c4d5ab6e6e2cd3d88b4d0e2f5ee3de025f3"
+  },
+  "transactions": [
+    {
+      "to": "0xE23eb92f0C76bF47f77F80D144e30F31b98450A9",
+      "value": "0",
+      "data": null,
+      "contractMethod": {
+        "inputs": [
+          {
+            "name": "gaugeAddresses",
+            "type": "address[]",
+            "internalType": "address[]"
+          },
+          {
+            "name": "amountsPerPeriod",
+            "type": "uint256[]",
+            "internalType": "uint256[]"
+          },
+          { "name": "maxPeriods", "type": "uint8[]", "internalType": "uint8[]" }
+        ],
+        "name": "setRecipientList",
+        "payable": false
+      },
+      "contractInputsValues": {
+        "gaugeAddresses": "[0x7d907D8D66B6CAd285D4349F507EcdfD11FD23D2, 0x6e654787251ae77Fe1873f93A5f220E00afa90E8]",
+        "amountsPerPeriod": "[6250000000000000000000, 17500000000000000000000]",
+        "maxPeriods": "[2, 2]"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Injecting 2 more weeks of ARB rewards on Arbitrum pools GHO/USDC/USDT (6250 per week) and ECLP GHO/aUSDCn (17500 per week) 

per this spreadsheet: https://docs.google.com/spreadsheets/d/1gZOBQ5AadhsU3nMoylEHV73wWsRyOtANbcR_8UaSH98/edit?gid=1846072370#gid=1846072370

TXN: https://app.onchainden.com/safes/arb1:0x9ff471F9f98F42E5151C7855fD1b5aa906b1AF7e/transactions/0x1aa8ac0ddd9edd9326082422b15f73862cc1d212540a9a423dd94172b51be632?nid=437751