### PR TITLE
HH_Bribe_Refund_August_2024

### DIFF
--- a/MaxiOps/brib_rebate_handling/08-2024/Bribe_Refund_August2024.md
+++ b/MaxiOps/brib_rebate_handling/08-2024/Bribe_Refund_August2024.md
@@ -1,0 +1,31 @@
+# Bribe rebates 
+
+Bribe rebates will be 3% of the total amount of tokens Balancer sends specifically to Hidden Hand during each month. For example in this txn: https://etherscan.io/tx/0xff71dd036a7db0c9289722bd62b22bb9ac55cc12774571e8f5f03db5b719486c the total amount sent by the Balancer: Protocol Fees Multisig was 327,937.028191 USDC, however the net transfer to the Hidden Hand contract was 163,968.549999 USDC which is what the refund would be based on. 
+
+### Asking for rebates    
+
+The current process for requesting rebates is the collect the transactions from a given month from the [Protocol Fees Multisig](https://etherscan.io/address/0x7c68c42de679ffb0f16216154c996c354cf1161b) contract address on etherscan. Once the Maxis have the transactions they will totalize the amount send to [Hidden hand's contract address](https://etherscan.io/address/0xe00fe722e5be7ad45b1a16066e431e47df476cec#readContract) and share the transaction links, totaly bribe amount, and refund amount (bribes * 0.03) for the given month.
+
+### Round dated August 2nd 2024
+
+Transaction: https://etherscan.io/tx/0x9c868532e6e63caedadcfa045358ab198ccedb023409e6918a74d88449465de4
+
+Net Transfer to HH: 143,480.94 - 3% of Transfer: 4304.43
+
+### Round dated August 16th 2024
+
+Transaction: https://etherscan.io/tx/0x5770eaba88b4df765346357da702040ed8687ea236da0cf583de5fa40ac01063
+
+Net Transfer to HH: 216,820.191 - 3% of Transfer: 6504.61
+
+### Round dated August 30th 2024
+
+Transaction: https://etherscan.io/tx/0x573dfed5b227e613075785a0542fd86fde998f9418f05504074f3d5b93901bb5
+
+Net Transfer to HH: 170,779.188297 - 3% of Transfer: 5,123.37
+
+### Grand totals for HH refund, August 2024
+
+Net Transfer to HH: 531080.319297
+
+*Total bribe refund for Augsut 2024 (3%): 15932.41 USDC*


### PR DESCRIPTION
Takes consideration of the 3 fee rounds transaction that occurred in August 2024.

Total refund amount: 15932.41 USDC