### PR TITLE
fix: thollander comment action has new input labels

### DIFF
--- a/.github/workflows/run_reports_reusable.yaml
+++ b/.github/workflows/run_reports_reusable.yaml
@@ -97,18 +97,18 @@ jobs:
         if: steps.check_files.outputs.validation_exists == 'true'
         uses: thollander/actions-comment-pull-request@v3
         with:
-          filePath: action-scripts/brownie/validate_bip_results.txt
-          comment_tag: validation_report
-          pr_number: ${{ inputs.pr_number }}
+          file-path: action-scripts/brownie/validate_bip_results.txt
+          comment-tag: validation_report
+          pr-number: ${{ inputs.pr_number }}
 
       - name: Post Payload Report as Comment
         continue-on-error: false
         uses: thollander/actions-comment-pull-request@v3
         if: steps.check_files.outputs.payload_reports == 'true'
         with:
-          filePath: action-scripts/brownie/payload_reports.txt
-          comment_tag: payload_report
-          pr_number: ${{ inputs.pr_number }}
+          file-path: action-scripts/brownie/payload_reports.txt
+          comment-tag: payload_report
+          pr-number: ${{ inputs.pr_number }}
 
       - name: Prettify code
         uses: creyD/prettier_action@v4.3


### PR DESCRIPTION
labels changed after this action got bumped to v3 in https://github.com/BalancerMaxis/multisig-ops/pull/1419
```
Warning: Unexpected input(s) 'filePath', 'comment_tag', 'pr_number', valid inputs are ['message', 'file-path', 'github-token', 'reactions', 'pr-number', 'comment-tag', 'mode', 'create-if-not-exists']
Run thollander/actions-comment-pull-request@v3
```
see https://github.com/BalancerMaxis/multisig-ops/actions/runs/11275424238/job/31356815550