### PR TITLE
tETH-wstETH-3bps-to-5bps

### DIFF
--- a/MaxiOps/PoolParameterChanges/PoolSwapFeeChanges/Mainnet/tETH-wstETH-3bps-to-5bps.json
+++ b/MaxiOps/PoolParameterChanges/PoolSwapFeeChanges/Mainnet/tETH-wstETH-3bps-to-5bps.json
@@ -1,0 +1,32 @@
+{
+  "version": "1.0",
+  "chainId": "1",
+  "createdAt": 1729772715011,
+  "meta": {
+    "name": "Transactions Batch",
+    "description": "",
+    "txBuilderVersion": "1.17.1",
+    "createdFromSafeAddress": "0xc38c5f97B34E175FFd35407fc91a937300E33860",
+    "createdFromOwnerAddress": "",
+    "checksum": "0x1e6b9c74986a401ae967cad4e5d45190a2910abad074241394ccbce281478bd3"
+  },
+  "transactions": [
+    {
+      "to": "0x1D13531bf6344c102280CE4c458781FBF14Dad14",
+      "value": "0",
+      "data": null,
+      "contractMethod": {
+        "inputs": [
+          {
+            "internalType": "uint256",
+            "name": "swapFeePercentage",
+            "type": "uint256"
+          }
+        ],
+        "name": "setSwapFeePercentage",
+        "payable": false
+      },
+      "contractInputsValues": { "swapFeePercentage": "500000000000000" }
+    }
+  ]
+}

--- a/MaxiOps/PoolParameterChanges/PoolSwapFeeChanges/Mainnet/tETH-wstETH-3bps-to-5bps.report.txt
+++ b/MaxiOps/PoolParameterChanges/PoolSwapFeeChanges/Mainnet/tETH-wstETH-3bps-to-5bps.report.txt
@@ -1,0 +1,17 @@
+FILENAME: `MaxiOps/PoolParameterChanges/PoolSwapFeeChanges/Mainnet/tETH-wstETH-3bps-to-5bps.json`
+MULTISIG: `multisigs/lm (mainnet:0xc38c5f97B34E175FFd35407fc91a937300E33860)`
+COMMIT: `7eca9d9f432ea5c86f70f01d1e0a57e6e981748c`
+CHAIN(S): `mainnet`
+TENDERLY: [`🟩 SUCCESS`](https://www.tdly.co/shared/simulation/85aa7e1f-ce7e-4f2f-9bda-2b6b49147d06)
+
+```
++----------------------+---------------------------------------------------------------------+-------+--------------------------+------------+----------+
+| fx_name              | to                                                                  | value | inputs                   | bip_number | tx_index |
++----------------------+---------------------------------------------------------------------+-------+--------------------------+------------+----------+
+| setSwapFeePercentage | 0x1D13531bf6344c102280CE4c458781FBF14Dad14 (pools/tETH/wstETH-1d13) | 0     | {                        | N/A        |   N/A    |
+|                      |                                                                     |       |   "swapFeePercentage": [ |            |          |
+|                      |                                                                     |       |     "500000000000000"    |            |          |
+|                      |                                                                     |       |   ]                      |            |          |
+|                      |                                                                     |       | }                        |            |          |
++----------------------+---------------------------------------------------------------------+-------+--------------------------+------------+----------+
+```


### PR DESCRIPTION
Moving fee from 3 bps to 5 bps at request to match Curve pool from Treehouse ETH team.
<img width="560" alt="image" src="https://github.com/user-attachments/assets/a7a82ff2-e6d9-4854-8a55-a944a4dab529">
