### PR TITLE
USDC-Injector-Scheduling-Rocketpool

### DIFF
--- a/MaxiOps/injectorScheduling/arbitrum/USDC-Injection-rETH-wETH.json
+++ b/MaxiOps/injectorScheduling/arbitrum/USDC-Injection-rETH-wETH.json
@@ -1,0 +1,42 @@
+{
+  "version": "1.0",
+  "chainId": "42161",
+  "createdAt": 1730671010918,
+  "meta": {
+    "name": "Transactions Batch",
+    "description": "",
+    "txBuilderVersion": "1.17.1",
+    "createdFromSafeAddress": "0x9ff471F9f98F42E5151C7855fD1b5aa906b1AF7e",
+    "createdFromOwnerAddress": "",
+    "checksum": "0xf720eafacb1a565da59ed25c0a2ab54494578ff053806c698e137247ccc2f76f"
+  },
+  "transactions": [
+    {
+      "to": "0xabC414cEE2F6E8Ee262d6dc106c86A3f627f84D2",
+      "value": "0",
+      "data": null,
+      "contractMethod": {
+        "inputs": [
+          {
+            "name": "gaugeAddresses",
+            "type": "address[]",
+            "internalType": "address[]"
+          },
+          {
+            "name": "amountsPerPeriod",
+            "type": "uint256[]",
+            "internalType": "uint256[]"
+          },
+          { "name": "maxPeriods", "type": "uint8[]", "internalType": "uint8[]" }
+        ],
+        "name": "setRecipientList",
+        "payable": false
+      },
+      "contractInputsValues": {
+        "gaugeAddresses": "[0x8ba2D53F34159C5C5e7add60B56C7dE3BBc1DA68]",
+        "amountsPerPeriod": "[1587600000]",
+        "maxPeriods": "[2]"
+      }
+    }
+  ]
+}

--- a/MaxiOps/injectorScheduling/base/USDC-Injection-rETH&MORE.json
+++ b/MaxiOps/injectorScheduling/base/USDC-Injection-rETH&MORE.json
@@ -1,0 +1,42 @@
+{
+  "version": "1.0",
+  "chainId": "8453",
+  "createdAt": 1730670281051,
+  "meta": {
+    "name": "Transactions Batch",
+    "description": "",
+    "txBuilderVersion": "1.17.1",
+    "createdFromSafeAddress": "0x9ff471F9f98F42E5151C7855fD1b5aa906b1AF7e",
+    "createdFromOwnerAddress": "",
+    "checksum": "0x96625695024106a6848fadcb9a56c52d661b036e750a5b15daeb283075e0a137"
+  },
+  "transactions": [
+    {
+      "to": "0xA6E7840Fc8193cFeBDdf177fa410038E5DD08f7A",
+      "value": "0",
+      "data": null,
+      "contractMethod": {
+        "inputs": [
+          {
+            "name": "gaugeAddresses",
+            "type": "address[]",
+            "internalType": "address[]"
+          },
+          {
+            "name": "amountsPerPeriod",
+            "type": "uint256[]",
+            "internalType": "uint256[]"
+          },
+          { "name": "maxPeriods", "type": "uint8[]", "internalType": "uint8[]" }
+        ],
+        "name": "setRecipientList",
+        "payable": false
+      },
+      "contractInputsValues": {
+        "gaugeAddresses": "[0x60ED9E5DA6437A6e19B7815e013e3426161e8044, 0x8D118063B521e0CB9947A934BE90f7e32d02b158]",
+        "amountsPerPeriod": "[20000000000, 1436400000]",
+        "maxPeriods": "[1,2]"
+      }
+    }
+  ]
+}

--- a/MaxiOps/injectorScheduling/optimism/USDC-Injection-rETH-wETH.json
+++ b/MaxiOps/injectorScheduling/optimism/USDC-Injection-rETH-wETH.json
@@ -1,0 +1,42 @@
+{
+  "version": "1.0",
+  "chainId": "10",
+  "createdAt": 1730671344645,
+  "meta": {
+    "name": "Transactions Batch",
+    "description": "",
+    "txBuilderVersion": "1.17.1",
+    "createdFromSafeAddress": "0x9ff471F9f98F42E5151C7855fD1b5aa906b1AF7e",
+    "createdFromOwnerAddress": "",
+    "checksum": "0xd9cd24699c52bb89a34f1c9bee59e40a427274d38e2a626d658bf567674e5af3"
+  },
+  "transactions": [
+    {
+      "to": "0x79D0F97D4D8c1Dd30b1Ea09746dB8847036AD92d",
+      "value": "0",
+      "data": null,
+      "contractMethod": {
+        "inputs": [
+          {
+            "name": "gaugeAddresses",
+            "type": "address[]",
+            "internalType": "address[]"
+          },
+          {
+            "name": "amountsPerPeriod",
+            "type": "uint256[]",
+            "internalType": "uint256[]"
+          },
+          { "name": "maxPeriods", "type": "uint8[]", "internalType": "uint8[]" }
+        ],
+        "name": "setRecipientList",
+        "payable": false
+      },
+      "contractInputsValues": {
+        "gaugeAddresses": "[0xF27D53f21d024643d50de50183932F17638229F6]",
+        "amountsPerPeriod": "[1080000000]",
+        "maxPeriods": "[2]"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Based on this spreadsheet to be loaded and exec'd for this weeks upcoming incentive cycle. Thursday 00:00 UTC. All funding is already sent to each injector. Only Base has overlap with MORE/USDC pool.

[Spreadsheet](https://docs.google.com/spreadsheets/d/1oXztVRUMJlXKEcT8giQcls7ZJxEk45BA2LsSpq3qeK4/edit?pli=1&gid=1846072370#gid=1846072370)