### PR TITLE
ci: enable poker on zkevm

### DIFF
--- a/MaxiOps/injectorScheduling/zkevm/set_poker_as_keeper.json
+++ b/MaxiOps/injectorScheduling/zkevm/set_poker_as_keeper.json
@@ -1,0 +1,53 @@
+{
+  "version": "1.0",
+  "chainId": "1101",
+  "createdAt": 1732256750075,
+  "meta": {
+    "name": "Transactions Batch",
+    "description": "",
+    "txBuilderVersion": "1.17.1",
+    "createdFromSafeAddress": "0xB59Ab49CA8d064E645Bf2c546d9FE6d1d4147a09",
+    "createdFromOwnerAddress": "",
+    "checksum": "0x0f2f27bc17da2bc14feadb01280cf275b18a46f654ccccb02b42230b1d7dd5be"
+  },
+  "transactions": [
+    {
+      "to": "0x3fb4ee715987eD98EDbeEb144F9b6b034C4c9F02",
+      "value": "0",
+      "data": null,
+      "contractMethod": {
+        "inputs": [
+          {
+            "name": "keeperRegistryAddress",
+            "type": "address",
+            "internalType": "address"
+          }
+        ],
+        "name": "setKeeperRegistryAddress",
+        "payable": false
+      },
+      "contractInputsValues": {
+        "keeperRegistryAddress": "0x737760C760FfEc370F84861E4Be4AFF7093Ffa3f"
+      }
+    },
+    {
+      "to": "0x2F1901f2A82fcC3Ee9010b809938816B3b06FA6A",
+      "value": "0",
+      "data": null,
+      "contractMethod": {
+        "inputs": [
+          {
+            "name": "keeperRegistryAddress",
+            "type": "address",
+            "internalType": "address"
+          }
+        ],
+        "name": "setKeeperRegistryAddress",
+        "payable": false
+      },
+      "contractInputsValues": {
+        "keeperRegistryAddress": "0x737760C760FfEc370F84861E4Be4AFF7093Ffa3f"
+      }
+    }
+  ]
+}

--- a/MaxiOps/injectorScheduling/zkevm/set_poker_as_keeper.report.txt
+++ b/MaxiOps/injectorScheduling/zkevm/set_poker_as_keeper.report.txt
@@ -1,0 +1,22 @@
+FILENAME: `MaxiOps/injectorScheduling/zkevm/set_poker_as_keeper.json`
+MULTISIG: `multisigs/feesManager (zkevm:0xB59Ab49CA8d064E645Bf2c546d9FE6d1d4147a09)`
+COMMIT: `3e187956a0db2ef14eccfed137c66f4f3a132ab2`
+CHAIN(S): `zkevm`
+TENDERLY: `🟪 SKIPPED (ValueError({'error': {'id': 'c6f9bf3e-4e93-433b-8888-fec81f57bc0a', 'slug': 'invalid_transaction_simulation', 'message': 'Unsupported network'}}))`
+
+```
++--------------------------+-------------------------------------------------------------------------------------------------------+-------+-------------------------------------------------------------------------------------+------------+----------+
+| fx_name                  | to                                                                                                    | value | inputs                                                                              | bip_number | tx_index |
++--------------------------+-------------------------------------------------------------------------------------------------------+-------+-------------------------------------------------------------------------------------+------------+----------+
+| setKeeperRegistryAddress | 0x3fb4ee715987eD98EDbeEb144F9b6b034C4c9F02 (maxiKeepers/gaugeRewardsInjectors/matic_rewards_injector) | 0     | {                                                                                   | N/A        |   N/A    |
+|                          |                                                                                                       |       |   "keeperRegistryAddress": [                                                        |            |          |
+|                          |                                                                                                       |       |     "0x737760C760FfEc370F84861E4Be4AFF7093Ffa3f (EOA/keepers/github_actions_poker)" |            |          |
+|                          |                                                                                                       |       |   ]                                                                                 |            |          |
+|                          |                                                                                                       |       | }                                                                                   |            |          |
+| setKeeperRegistryAddress | 0x2F1901f2A82fcC3Ee9010b809938816B3b06FA6A (maxiKeepers/gaugeRewardsInjectors/usdc_rewards_injector)  | 0     | {                                                                                   | N/A        |   N/A    |
+|                          |                                                                                                       |       |   "keeperRegistryAddress": [                                                        |            |          |
+|                          |                                                                                                       |       |     "0x737760C760FfEc370F84861E4Be4AFF7093Ffa3f (EOA/keepers/github_actions_poker)" |            |          |
+|                          |                                                                                                       |       |   ]                                                                                 |            |          |
+|                          |                                                                                                       |       | }                                                                                   |            |          |
++--------------------------+-------------------------------------------------------------------------------------------------------+-------+-------------------------------------------------------------------------------------+------------+----------+
+```

--- a/action-scripts/brownie/scripts/pokeInjectors.py
+++ b/action-scripts/brownie/scripts/pokeInjectors.py
@@ -3,11 +3,7 @@ from brownie import network, accounts, Contract
 import os
 
 
-CHAINS_TO_KEEP = [
-    #    "zkevm-main", # currently running in defender due to rpc issues
-    "mode-main",
-    "fraxtal-main",
-]
+CHAINS_TO_KEEP = ["zkevm-main", "mode-main", "fraxtal-main"]
 
 
 def main():


### PR DESCRIPTION
closes #1333 

this will allow us to remove it from defender and thus have all non chainlink keepers in one place

no active schedules on either injector, so no issues with missing a cycle