### PR TITLE
HH Refund for October and November

### DIFF
--- a/MaxiOps/brib_rebate_handling/10-2024/Bribe_Refund_October2024.md
+++ b/MaxiOps/brib_rebate_handling/10-2024/Bribe_Refund_October2024.md
@@ -1,0 +1,25 @@
+# Bribe rebates 
+
+Bribe rebates will be 3% of the total amount of tokens Balancer sends specifically to Hidden Hand during each month. For example in this txn: https://etherscan.io/tx/0xff71dd036a7db0c9289722bd62b22bb9ac55cc12774571e8f5f03db5b719486c the total amount sent by the Balancer: Protocol Fees Multisig was 327,937.028191 USDC, however the net transfer to the Hidden Hand contract was 163,968.549999 USDC which is what the refund would be based on. 
+
+### Asking for rebates    
+
+The current process for requesting rebates is the collect the transactions from a given month from the [Protocol Fees Multisig](https://etherscan.io/address/0x7c68c42de679ffb0f16216154c996c354cf1161b) contract address on etherscan. Once the Maxis have the transactions they will totalize the amount send to [Hidden hand's contract address](https://etherscan.io/address/0xe00fe722e5be7ad45b1a16066e431e47df476cec#readContract) and share the transaction links, totaly bribe amount, and refund amount (bribes * 0.03) for the given month.
+
+### Round dated October 10th 2024
+
+Transaction: https://etherscan.io/tx/0xfc03bfa98caa93397e20ce9bf942b1a767a5d2a0955c8910339ea4c7aae9f34b
+
+Net Transfer to HH: 142,233.13 - 3% of Transfer: 4266.99
+
+### Round dated October 25th 2024
+
+Transaction: https://etherscan.io/tx/0xd077349c1c8898c272bd45108218a6d40c2c68a8624172e2ada56b074f0f6567
+
+Net Transfer to HH: 146,194.787099 - 3% of Transfer: 4385.84
+
+### Grand totals for HH refund, September 2024
+
+Net Transfer to HH: 288427.912099
+
+*Total bribe refund for October 2024 (3%): 8652.83 USDC*

--- a/MaxiOps/brib_rebate_handling/11-2204/Bribe_Refund_November2024.md
+++ b/MaxiOps/brib_rebate_handling/11-2204/Bribe_Refund_November2024.md
@@ -1,0 +1,25 @@
+# Bribe rebates 
+
+Bribe rebates will be 3% of the total amount of tokens Balancer sends specifically to Hidden Hand during each month. For example in this txn: https://etherscan.io/tx/0xff71dd036a7db0c9289722bd62b22bb9ac55cc12774571e8f5f03db5b719486c the total amount sent by the Balancer: Protocol Fees Multisig was 327,937.028191 USDC, however the net transfer to the Hidden Hand contract was 163,968.549999 USDC which is what the refund would be based on. 
+
+### Asking for rebates    
+
+The current process for requesting rebates is the collect the transactions from a given month from the [Protocol Fees Multisig](https://etherscan.io/address/0x7c68c42de679ffb0f16216154c996c354cf1161b) contract address on etherscan. Once the Maxis have the transactions they will totalize the amount send to [Hidden hand's contract address](https://etherscan.io/address/0xe00fe722e5be7ad45b1a16066e431e47df476cec#readContract) and share the transaction links, totaly bribe amount, and refund amount (bribes * 0.03) for the given month.
+
+### Round dated November 7th 2024
+
+Transaction: https://etherscan.io/tx/0x2ebe215590f33876766097e5e49f90689bc4f44f170f6841e9e5d8055c07e5ff
+
+Net Transfer to HH: 138,729.20 - 3% of Transfer: 4161.87
+
+### Round dated November 22nd 2024
+
+Transaction: https://etherscan.io/tx/0x4e3fcfc04b9719f032b1e7c554d794ea223c51fdbdb17e2cdb07952c674f033e
+
+Net Transfer to HH: 280,804.2395 - 3% of Transfer: 8424.13
+
+### Grand totals for HH refund, November 2024
+
+Net Transfer to HH: 419533.4395
+
+*Total bribe refund for November 2024 (3%): 12586.00 USDC*


### PR DESCRIPTION
Details all in md file.

October net: 8652.83 USDC
November net: 12586.00 USDC
Total of both: 21238.83 USDC