### PR TITLE
NET Injector v1 - Accept Ownership to Omnisafe

### DIFF
--- a/MaxiOps/injectorScheduling/mainnet/setup_NET_injector.json
+++ b/MaxiOps/injectorScheduling/mainnet/setup_NET_injector.json
@@ -1,0 +1,26 @@
+{
+  "version": "1.0",
+  "chainId": "1",
+  "createdAt": 1730279673289,
+  "meta": {
+    "name": "Transactions Batch",
+    "description": "",
+    "txBuilderVersion": "1.17.1",
+    "createdFromSafeAddress": "0x9ff471F9f98F42E5151C7855fD1b5aa906b1AF7e",
+    "createdFromOwnerAddress": "",
+    "checksum": ""
+  },
+  "transactions": [
+    {
+      "to": "0x9be5ce14d1fd02517682aec14c7162328e9e386e",
+      "value": "0",
+      "data": null,
+      "contractMethod": {
+        "inputs": [],
+        "name": "acceptOwnership",
+        "payable": false
+      },
+      "contractInputsValues": null
+    }
+  ]
+}


### PR DESCRIPTION
- Utilize vote incentive recycling omnisafe as for others (e.g. USDC on mainnet)
- NET Injector deployed [here](https://etherscan.io/address/0x9be5ce14d1fd02517682aec14c7162328e9e386e)
- keeper configured as per Trit