### PR TITLE
chore: transfer susds delta

### DIFF
--- a/MaxiOps/sablier/transfer-susds-delta-tritium.json
+++ b/MaxiOps/sablier/transfer-susds-delta-tritium.json
@@ -1,0 +1,32 @@
+{
+  "version": "1.0",
+  "chainId": "1",
+  "createdAt": 1734377045207,
+  "meta": {
+    "name": "Transactions Batch",
+    "description": "",
+    "txBuilderVersion": "1.17.1",
+    "createdFromSafeAddress": "0x166f54F44F271407f24AA1BE415a730035637325",
+    "createdFromOwnerAddress": "",
+    "checksum": "0x296a921de9f3acbca235a5e618222bd06e55fb01ccc6abf1cafc8a7c6c547f7e"
+  },
+  "transactions": [
+    {
+      "to": "0xa3931d71877C0E7a3148CB7Eb4463524FEc27fbD",
+      "value": "0",
+      "data": null,
+      "contractMethod": {
+        "inputs": [
+          { "internalType": "address", "name": "to", "type": "address" },
+          { "internalType": "uint256", "name": "value", "type": "uint256" }
+        ],
+        "name": "transfer",
+        "payable": false
+      },
+      "contractInputsValues": {
+        "to": "0x27e472f2625D6d4913F6cb5b99DAAadb58Da1D93",
+        "value": "6106491848689630800180"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
amount is derived as follows:

```
➜ uint256(80690947000000000000000) - uint256(46451965348689630800180)
Type: uint256
├ Hex: 0x740195275f7a01256cc
├ Hex (full word): 0x000000000000000000000000000000000000000000000740195275f7a01256cc
└ Decimal: 34238981651310369199820
➜ uint256(80690947000000000000000) / uint256(2) - uint256(34238981651310369199820)
Type: uint256
├ Hex: 0x14b08991ecd83d76934
├ Hex (full word): 0x00000000000000000000000000000000000000000000014b08991ecd83d76934
└ Decimal: 6106491848689630800180
```

`80690947000000000000000` is original amount for two quarters
`46451965348689630800180` is what was clawed back by payments msig
so ~= 6k too little (which passes sanity check of 80k/2=40k per quarter)