### PR TITLE
GEAR_minWaitPeriod_Update_518400

### DIFF
--- a/MaxiOps/injectorScheduling/mainnet/GEAR_minWaitPeriod_Update_518400.json
+++ b/MaxiOps/injectorScheduling/mainnet/GEAR_minWaitPeriod_Update_518400.json
@@ -1,0 +1,28 @@
+{
+  "version": "1.0",
+  "chainId": "1",
+  "createdAt": 1735302837334,
+  "meta": {
+    "name": "Transactions Batch",
+    "description": "",
+    "txBuilderVersion": "1.17.1",
+    "createdFromSafeAddress": "0x9ff471F9f98F42E5151C7855fD1b5aa906b1AF7e",
+    "createdFromOwnerAddress": "",
+    "checksum": "0x6c5726100d0602fb28892d002fafe02a19724a6bb87f23fac76a090640fb0e5e"
+  },
+  "transactions": [
+    {
+      "to": "0xfa7b21B30325DBbd4A71ee2B2EDE74A7d8A2c0E4",
+      "value": "0",
+      "data": null,
+      "contractMethod": {
+        "inputs": [
+          { "name": "period", "type": "uint256", "internalType": "uint256" }
+        ],
+        "name": "setMinWaitPeriodSeconds",
+        "payable": false
+      },
+      "contractInputsValues": { "period": "518400" }
+    }
+  ]
+}

--- a/MaxiOps/injectorScheduling/mainnet/GEAR_minWaitPeriod_Update_518400.report.txt
+++ b/MaxiOps/injectorScheduling/mainnet/GEAR_minWaitPeriod_Update_518400.report.txt
@@ -1,0 +1,17 @@
+FILENAME: `MaxiOps/injectorScheduling/mainnet/GEAR_minWaitPeriod_Update_518400.json`
+MULTISIG: `multisigs/maxi_omni (mainnet:0x9ff471F9f98F42E5151C7855fD1b5aa906b1AF7e)`
+COMMIT: `96fc2d06757d849ba3f6c8b1e67cba32bb26f133`
+CHAIN(S): `mainnet`
+TENDERLY: [`🟩 SUCCESS`](https://www.tdly.co/shared/simulation/00710e71-f808-4bf2-854f-596c9f536d72)
+
+```
++-------------------------+--------------------------------------------------------------------------+-------+---------------+------------+----------+
+| fx_name                 | to                                                                       | value | inputs        | bip_number | tx_index |
++-------------------------+--------------------------------------------------------------------------+-------+---------------+------------+----------+
+| setMinWaitPeriodSeconds | 0xfa7b21B30325DBbd4A71ee2B2EDE74A7d8A2c0E4 (maxiKeepers/injectorV2/GEAR) | 0     | {             | N/A        |   N/A    |
+|                         |                                                                          |       |   "period": [ |            |          |
+|                         |                                                                          |       |     "518400"  |            |          |
+|                         |                                                                          |       |   ]           |            |          |
+|                         |                                                                          |       | }             |            |          |
++-------------------------+--------------------------------------------------------------------------+-------+---------------+------------+----------+
+```


### PR DESCRIPTION
To fix injections for cow pool set minWaitPeriod to 7 days or less. Currently too high causing a delay.