### PR TITLE
wstETH-Transfer&InjectorSchedule-Lido-wstETH-wETH

### DIFF
--- a/MaxiOps/injectorScheduling/mainnet/wstETH-Transfer&InjectorSchedule-Lido-wstETH-wETH.json
+++ b/MaxiOps/injectorScheduling/mainnet/wstETH-Transfer&InjectorSchedule-Lido-wstETH-wETH.json
@@ -1,0 +1,65 @@
+{
+  "version": "1.0",
+  "chainId": "1",
+  "createdAt": 1735520773725,
+  "meta": {
+    "name": "Transactions Batch",
+    "description": "",
+    "txBuilderVersion": "1.17.1",
+    "createdFromSafeAddress": "0x9ff471F9f98F42E5151C7855fD1b5aa906b1AF7e",
+    "createdFromOwnerAddress": "",
+    "checksum": "0x73e82055a5382a95f98f703145f6409b970869a4d266a67b4e6ebbde7774f206"
+  },
+  "transactions": [
+    {
+      "to": "0x4aC87aEa2A3A99f34Fec78A6A73Bc495893b2838",
+      "value": "0",
+      "data": null,
+      "contractMethod": {
+        "inputs": [
+          {
+            "internalType": "address[]",
+            "name": "recipients",
+            "type": "address[]"
+          },
+          {
+            "internalType": "uint256",
+            "name": "amountPerPeriod",
+            "type": "uint256"
+          },
+          { "internalType": "uint8", "name": "maxPeriods", "type": "uint8" },
+          {
+            "internalType": "uint56",
+            "name": "doNotStartBeforeTimestamp",
+            "type": "uint56"
+          }
+        ],
+        "name": "addRecipients",
+        "payable": false
+      },
+      "contractInputsValues": {
+        "recipients": "[0x4b891340b51889f438a03dc0e8aaafb0bc89e7a6]",
+        "amountPerPeriod": "927500000000000000",
+        "maxPeriods": "4",
+        "doNotStartBeforeTimestamp": "1735653600"
+      }
+    },
+    {
+      "to": "0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0",
+      "value": "0",
+      "data": null,
+      "contractMethod": {
+        "inputs": [
+          { "name": "recipient", "type": "address", "internalType": "address" },
+          { "name": "amount", "type": "uint256", "internalType": "uint256" }
+        ],
+        "name": "transfer",
+        "payable": false
+      },
+      "contractInputsValues": {
+        "recipient": "0x4aC87aEa2A3A99f34Fec78A6A73Bc495893b2838",
+        "amount": "3710000000000000000"
+      }
+    }
+  ]
+}

--- a/MaxiOps/injectorScheduling/mainnet/wstETH-Transfer&InjectorSchedule-Lido-wstETH-wETH.report.txt
+++ b/MaxiOps/injectorScheduling/mainnet/wstETH-Transfer&InjectorSchedule-Lido-wstETH-wETH.report.txt
@@ -1,0 +1,39 @@
+FILENAME: `MaxiOps/injectorScheduling/mainnet/wstETH-Transfer&InjectorSchedule-Lido-wstETH-wETH.json`
+MULTISIG: `multisigs/maxi_omni (mainnet:0x9ff471F9f98F42E5151C7855fD1b5aa906b1AF7e)`
+COMMIT: `2402342ec0a5e481e67cd6118f02f877f115e785`
+CHAIN(S): `mainnet`
+TENDERLY: [`🟩 SUCCESS`](https://www.tdly.co/shared/simulation/22f11c5e-2b87-4cf9-980c-ee3c1fbeabb4)
+
+```
++----------+---------------------------------------------------+------------------------------------------------+---------------------------------+-----+----------+
+| function | token_symbol                                      | recipient                                      | amount                          | bip | tx_index |
++----------+---------------------------------------------------+------------------------------------------------+---------------------------------+-----+----------+
+| transfer | wstETH:0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0 | N/A:0x4aC87aEa2A3A99f34Fec78A6A73Bc495893b2838 | 3.71 (RAW: 3710000000000000000) | N/A |    1     |
++----------+---------------------------------------------------+------------------------------------------------+---------------------------------+-----+----------+
+```
+FILENAME: `MaxiOps/injectorScheduling/mainnet/wstETH-Transfer&InjectorSchedule-Lido-wstETH-wETH.json`
+MULTISIG: `multisigs/maxi_omni (mainnet:0x9ff471F9f98F42E5151C7855fD1b5aa906b1AF7e)`
+COMMIT: `2402342ec0a5e481e67cd6118f02f877f115e785`
+CHAIN(S): `mainnet`
+TENDERLY: [`🟩 SUCCESS`](https://www.tdly.co/shared/simulation/b8c46fcf-50b3-492f-bf5c-403f4399b842)
+
+```
++---------------+--------------------------------------------------------+-------+--------------------------------------------------------------------------------------------+------------+----------+
+| fx_name       | to                                                     | value | inputs                                                                                     | bip_number | tx_index |
++---------------+--------------------------------------------------------+-------+--------------------------------------------------------------------------------------------+------------+----------+
+| addRecipients | 0x4aC87aEa2A3A99f34Fec78A6A73Bc495893b2838 (Not Found) | 0     | {                                                                                          | N/A        |   N/A    |
+|               |                                                        |       |   "recipients": [                                                                          |            |          |
+|               |                                                        |       |     "0x4B891340b51889f438a03DC0e8aAAFB0Bc89e7A6 (gauges/Aave Lido wETH-wstETH-gauge-4b89)" |            |          |
+|               |                                                        |       |   ],                                                                                       |            |          |
+|               |                                                        |       |   "amountPerPeriod": [                                                                     |            |          |
+|               |                                                        |       |     "raw:927500000000000000, 18 decimals:0.9275, 6 decimals: 927500000000"                 |            |          |
+|               |                                                        |       |   ],                                                                                       |            |          |
+|               |                                                        |       |   "maxPeriods": [                                                                          |            |          |
+|               |                                                        |       |     4                                                                                      |            |          |
+|               |                                                        |       |   ],                                                                                       |            |          |
+|               |                                                        |       |   "doNotStartBeforeTimestamp": [                                                           |            |          |
+|               |                                                        |       |     1735653600                                                                             |            |          |
+|               |                                                        |       |   ]                                                                                        |            |          |
+|               |                                                        |       | }                                                                                          |            |          |
++---------------+--------------------------------------------------------+-------+--------------------------------------------------------------------------------------------+------------+----------+
+```


### PR DESCRIPTION
Per Lidos request distribute 3.71 wstETH over 4 weeks. Equal to 0.9275 wstETH per week starting ASAP. This TXN will start streaming upon execution. The injector and keeper will be funded upon execution.