### PR TITLE
USDC-Arbitrum-Base-v3-Bootstrapping-1

### DIFF
--- a/MaxiOps/CCTP_Bridge/send/USDC-Arbitrum-Base-v3-Bootstrapping-1.json
+++ b/MaxiOps/CCTP_Bridge/send/USDC-Arbitrum-Base-v3-Bootstrapping-1.json
@@ -1,0 +1,139 @@
+{
+  "version": "1.0",
+  "chainId": "1",
+  "createdAt": 1738705164338,
+  "meta": {
+    "name": "Transactions Batch",
+    "description": "",
+    "txBuilderVersion": "1.16.5",
+    "createdFromSafeAddress": "0xc38c5f97B34E175FFd35407fc91a937300E33860",
+    "createdFromOwnerAddress": "",
+    "checksum": "0x301f5a7132d04fe310a2eaaac8a7303393ed01c2ca5fbbca2c2a09b1de2755f4"
+  },
+  "transactions": [
+    {
+      "to": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+      "value": "0",
+      "data": null,
+      "contractMethod": {
+        "inputs": [
+          {
+            "name": "spender",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "value",
+            "type": "uint256",
+            "internalType": "uint256"
+          }
+        ],
+        "name": "approve",
+        "payable": false
+      },
+      "contractInputsValues": {
+        "spender": "0xBd3fa81B58Ba92a82136038B25aDec7066af3155",
+        "value": "30000000000"
+      }
+    },
+    {
+      "to": "0xBd3fa81B58Ba92a82136038B25aDec7066af3155",
+      "value": "0",
+      "data": null,
+      "contractMethod": {
+        "inputs": [
+          {
+            "name": "amount",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "destinationDomain",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "mintRecipient",
+            "type": "bytes32",
+            "internalType": "bytes32"
+          },
+          {
+            "name": "burnToken",
+            "type": "address",
+            "internalType": "address"
+          }
+        ],
+        "name": "depositForBurn",
+        "payable": false
+      },
+      "contractInputsValues": {
+        "amount": "30000000000",
+        "destinationDomain": "3",
+        "mintRecipient": "0x0000000000000000000000009ff471F9f98F42E5151C7855fD1b5aa906b1AF7e",
+        "burnToken": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
+      }
+    },
+    {
+      "to": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+      "value": "0",
+      "data": null,
+      "contractMethod": {
+        "inputs": [
+          {
+            "name": "spender",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "value",
+            "type": "uint256",
+            "internalType": "uint256"
+          }
+        ],
+        "name": "approve",
+        "payable": false
+      },
+      "contractInputsValues": {
+        "spender": "0xBd3fa81B58Ba92a82136038B25aDec7066af3155",
+        "value": "15000000000"
+      }
+    },
+    {
+      "to": "0xBd3fa81B58Ba92a82136038B25aDec7066af3155",
+      "value": "0",
+      "data": null,
+      "contractMethod": {
+        "inputs": [
+          {
+            "name": "amount",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "destinationDomain",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "mintRecipient",
+            "type": "bytes32",
+            "internalType": "bytes32"
+          },
+          {
+            "name": "burnToken",
+            "type": "address",
+            "internalType": "address"
+          }
+        ],
+        "name": "depositForBurn",
+        "payable": false
+      },
+      "contractInputsValues": {
+        "amount": "15000000000",
+        "destinationDomain": "6",
+        "mintRecipient": "0x0000000000000000000000009ff471F9f98F42E5151C7855fD1b5aa906b1AF7e",
+        "burnToken": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
+      }
+    }
+  ]
+}

--- a/MaxiOps/CCTP_Bridge/send/USDC-Arbitrum-Base-v3-Bootstrapping-1.report.txt
+++ b/MaxiOps/CCTP_Bridge/send/USDC-Arbitrum-Base-v3-Bootstrapping-1.report.txt
@@ -1,0 +1,56 @@
+FILENAME: `MaxiOps/CCTP_Bridge/send/USDC-Arbitrum-Base-v3-Bootstrapping-1.json`
+MULTISIG: `multisigs/lm (mainnet:0xc38c5f97B34E175FFd35407fc91a937300E33860)`
+COMMIT: `c91bd6fe077ad5a989cc022e7ce31bf05371ca14`
+CHAIN(S): `mainnet`
+TENDERLY: [`🟩 SUCCESS`](https://www.tdly.co/shared/simulation/c1f966b6-4a6d-4aa7-a156-6cd9ace0f0ee)
+
+```
++----------------+--------------------------------------------------------------------+-------+--------------------------------------------------------------------------+------------+----------+
+| fx_name        | to                                                                 | value | inputs                                                                   | bip_number | tx_index |
++----------------+--------------------------------------------------------------------+-------+--------------------------------------------------------------------------+------------+----------+
+| approve        | 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48 (tokens/USDC)           | 0     | {                                                                        | N/A        |   N/A    |
+|                |                                                                    |       |   "spender": [                                                           |            |          |
+|                |                                                                    |       |     "0xBd3fa81B58Ba92a82136038B25aDec7066af3155 (circle/cctp_messenger)" |            |          |
+|                |                                                                    |       |   ],                                                                     |            |          |
+|                |                                                                    |       |   "value": [                                                             |            |          |
+|                |                                                                    |       |     "raw:30000000000, 18 decimals:3E-8, 6 decimals: 30000"               |            |          |
+|                |                                                                    |       |   ]                                                                      |            |          |
+|                |                                                                    |       | }                                                                        |            |          |
+| depositForBurn | 0xBd3fa81B58Ba92a82136038B25aDec7066af3155 (circle/cctp_messenger) | 0     | {                                                                        | N/A        |   N/A    |
+|                |                                                                    |       |   "amount": [                                                            |            |          |
+|                |                                                                    |       |     "raw:30000000000, 18 decimals:3E-8, 6 decimals: 30000"               |            |          |
+|                |                                                                    |       |   ],                                                                     |            |          |
+|                |                                                                    |       |   "destinationDomain": [                                                 |            |          |
+|                |                                                                    |       |     "3"                                                                  |            |          |
+|                |                                                                    |       |   ],                                                                     |            |          |
+|                |                                                                    |       |   "mintRecipient": [                                                     |            |          |
+|                |                                                                    |       |     "0x0000000000000000000000009ff471F9f98F42E5151C7855fD1b5aa906b1AF7e" |            |          |
+|                |                                                                    |       |   ],                                                                     |            |          |
+|                |                                                                    |       |   "burnToken": [                                                         |            |          |
+|                |                                                                    |       |     "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48 (tokens/USDC)"           |            |          |
+|                |                                                                    |       |   ]                                                                      |            |          |
+|                |                                                                    |       | }                                                                        |            |          |
+| approve        | 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48 (tokens/USDC)           | 0     | {                                                                        | N/A        |   N/A    |
+|                |                                                                    |       |   "spender": [                                                           |            |          |
+|                |                                                                    |       |     "0xBd3fa81B58Ba92a82136038B25aDec7066af3155 (circle/cctp_messenger)" |            |          |
+|                |                                                                    |       |   ],                                                                     |            |          |
+|                |                                                                    |       |   "value": [                                                             |            |          |
+|                |                                                                    |       |     "raw:15000000000, 18 decimals:1.5E-8, 6 decimals: 15000"             |            |          |
+|                |                                                                    |       |   ]                                                                      |            |          |
+|                |                                                                    |       | }                                                                        |            |          |
+| depositForBurn | 0xBd3fa81B58Ba92a82136038B25aDec7066af3155 (circle/cctp_messenger) | 0     | {                                                                        | N/A        |   N/A    |
+|                |                                                                    |       |   "amount": [                                                            |            |          |
+|                |                                                                    |       |     "raw:15000000000, 18 decimals:1.5E-8, 6 decimals: 15000"             |            |          |
+|                |                                                                    |       |   ],                                                                     |            |          |
+|                |                                                                    |       |   "destinationDomain": [                                                 |            |          |
+|                |                                                                    |       |     "6"                                                                  |            |          |
+|                |                                                                    |       |   ],                                                                     |            |          |
+|                |                                                                    |       |   "mintRecipient": [                                                     |            |          |
+|                |                                                                    |       |     "0x0000000000000000000000009ff471F9f98F42E5151C7855fD1b5aa906b1AF7e" |            |          |
+|                |                                                                    |       |   ],                                                                     |            |          |
+|                |                                                                    |       |   "burnToken": [                                                         |            |          |
+|                |                                                                    |       |     "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48 (tokens/USDC)"           |            |          |
+|                |                                                                    |       |   ]                                                                      |            |          |
+|                |                                                                    |       | }                                                                        |            |          |
++----------------+--------------------------------------------------------------------+-------+--------------------------------------------------------------------------+------------+----------+
+```


### PR DESCRIPTION
Bridging 30000 USDC to Arbitrum and 15000 USDC to Base for initial bootstrapping of launch pools on each network.

Will follow this [notion](https://www.notion.so/18de395e22818014b713e5e5f35095a4?v=18de395e228180f7ae12000cf007f5da) page with flexibility for new partners arising.

Due to size of funds being bridged, this payload will not be loaded until review and approved by team members. 