### PR TITLE
StableSurge-LaunchPools-config

### DIFF
--- a/MaxiOps/PoolParameterChanges/PoolStableSurgeParams/Arbitrum/StableSurge-LaunchPools-Config.json
+++ b/MaxiOps/PoolParameterChanges/PoolStableSurgeParams/Arbitrum/StableSurge-LaunchPools-Config.json
@@ -1,0 +1,141 @@
+{
+  "version": "1.0",
+  "chainId": "42161",
+  "createdAt": 1739308751399,
+  "meta": {
+    "name": "Transactions Batch",
+    "description": "",
+    "txBuilderVersion": "1.18.0",
+    "createdFromSafeAddress": "0x9ff471F9f98F42E5151C7855fD1b5aa906b1AF7e",
+    "createdFromOwnerAddress": "",
+    "checksum": "0x0bfd5256b3a025e98764f3b274003ccdf7abc14d6a6a6b263534b96dd7f1ac5b"
+  },
+  "transactions": [
+    {
+      "to": "0x0Fa0f9990D7969a7aE6f9961d663E4A201Ed6417",
+      "value": "0",
+      "data": null,
+      "contractMethod": {
+        "inputs": [
+          { "internalType": "address", "name": "pool", "type": "address" },
+          {
+            "internalType": "uint256",
+            "name": "newMaxSurgeSurgeFeePercentage",
+            "type": "uint256"
+          }
+        ],
+        "name": "setMaxSurgeFeePercentage",
+        "payable": false
+      },
+      "contractInputsValues": {
+        "pool": "0x7F98F42F9550F92DEE91344d6B5Ab11A9FEc2b4E",
+        "newMaxSurgeSurgeFeePercentage": "50000000000000000"
+      }
+    },
+    {
+      "to": "0x0Fa0f9990D7969a7aE6f9961d663E4A201Ed6417",
+      "value": "0",
+      "data": null,
+      "contractMethod": {
+        "inputs": [
+          { "internalType": "address", "name": "pool", "type": "address" },
+          {
+            "internalType": "uint256",
+            "name": "newSurgeThresholdPercentage",
+            "type": "uint256"
+          }
+        ],
+        "name": "setSurgeThresholdPercentage",
+        "payable": false
+      },
+      "contractInputsValues": {
+        "pool": "0x7F98F42F9550F92DEE91344d6B5Ab11A9FEc2b4E",
+        "newSurgeThresholdPercentage": "100000000000000000"
+      }
+    },
+    {
+      "to": "0x0Fa0f9990D7969a7aE6f9961d663E4A201Ed6417",
+      "value": "0",
+      "data": null,
+      "contractMethod": {
+        "inputs": [
+          { "internalType": "address", "name": "pool", "type": "address" },
+          {
+            "internalType": "uint256",
+            "name": "newMaxSurgeSurgeFeePercentage",
+            "type": "uint256"
+          }
+        ],
+        "name": "setMaxSurgeFeePercentage",
+        "payable": false
+      },
+      "contractInputsValues": {
+        "pool": "0xc2B0D1A1B4cdDA10185859B5a5c543024c2df869",
+        "newMaxSurgeSurgeFeePercentage": "50000000000000000"
+      }
+    },
+    {
+      "to": "0x0Fa0f9990D7969a7aE6f9961d663E4A201Ed6417",
+      "value": "0",
+      "data": null,
+      "contractMethod": {
+        "inputs": [
+          { "internalType": "address", "name": "pool", "type": "address" },
+          {
+            "internalType": "uint256",
+            "name": "newSurgeThresholdPercentage",
+            "type": "uint256"
+          }
+        ],
+        "name": "setSurgeThresholdPercentage",
+        "payable": false
+      },
+      "contractInputsValues": {
+        "pool": "0xc2B0D1A1B4cdDA10185859B5a5c543024c2df869",
+        "newSurgeThresholdPercentage": "50000000000000000"
+      }
+    },
+    {
+      "to": "0x0Fa0f9990D7969a7aE6f9961d663E4A201Ed6417",
+      "value": "0",
+      "data": null,
+      "contractMethod": {
+        "inputs": [
+          { "internalType": "address", "name": "pool", "type": "address" },
+          {
+            "internalType": "uint256",
+            "name": "newMaxSurgeSurgeFeePercentage",
+            "type": "uint256"
+          }
+        ],
+        "name": "setMaxSurgeFeePercentage",
+        "payable": false
+      },
+      "contractInputsValues": {
+        "pool": "0x19B001e6Bc2d89154c18e2216eec5C8c6047b6d8",
+        "newMaxSurgeSurgeFeePercentage": "50000000000000000"
+      }
+    },
+    {
+      "to": "0x0Fa0f9990D7969a7aE6f9961d663E4A201Ed6417",
+      "value": "0",
+      "data": null,
+      "contractMethod": {
+        "inputs": [
+          { "internalType": "address", "name": "pool", "type": "address" },
+          {
+            "internalType": "uint256",
+            "name": "newSurgeThresholdPercentage",
+            "type": "uint256"
+          }
+        ],
+        "name": "setSurgeThresholdPercentage",
+        "payable": false
+      },
+      "contractInputsValues": {
+        "pool": "0x19B001e6Bc2d89154c18e2216eec5C8c6047b6d8",
+        "newSurgeThresholdPercentage": "50000000000000000"
+      }
+    }
+  ]
+}

--- a/MaxiOps/PoolParameterChanges/PoolStableSurgeParams/Arbitrum/StableSurge-LaunchPools-Config.report.txt
+++ b/MaxiOps/PoolParameterChanges/PoolStableSurgeParams/Arbitrum/StableSurge-LaunchPools-Config.report.txt
@@ -1,0 +1,60 @@
+FILENAME: `MaxiOps/PoolParameterChanges/PoolStableSurgeParams/Arbitrum/StableSurge-LaunchPools-Config.json`
+MULTISIG: `multisigs/maxi_omni (arbitrum:0x9ff471F9f98F42E5151C7855fD1b5aa906b1AF7e)`
+COMMIT: `e8d80eb702582ac9ed567b6bfb44b1a41b82286b`
+CHAIN(S): `arbitrum`
+TENDERLY: [`🟩 SUCCESS`](https://www.tdly.co/shared/simulation/69090eaa-1230-4b3a-98f0-7f268aa6f50d)
+
+```
++-----------------------------+---------------------------------------------------------------------------------------+-------+--------------------------------------------------------+------------+----------+
+| fx_name                     | to                                                                                    | value | inputs                                                 | bip_number | tx_index |
++-----------------------------+---------------------------------------------------------------------------------------+-------+--------------------------------------------------------+------------+----------+
+| setMaxSurgeFeePercentage    | 0x0Fa0f9990D7969a7aE6f9961d663E4A201Ed6417 (20250121-v3-stable-surge/StableSurgeHook) | 0     | {                                                      | N/A        |   N/A    |
+|                             |                                                                                       |       |   "pool": [                                            |            |          |
+|                             |                                                                                       |       |     "0x7F98F42F9550F92DEE91344d6B5Ab11A9FEc2b4E (N/A)" |            |          |
+|                             |                                                                                       |       |   ],                                                   |            |          |
+|                             |                                                                                       |       |   "newMaxSurgeSurgeFeePercentage": [                   |            |          |
+|                             |                                                                                       |       |     "50000000000000000"                                |            |          |
+|                             |                                                                                       |       |   ]                                                    |            |          |
+|                             |                                                                                       |       | }                                                      |            |          |
+| setSurgeThresholdPercentage | 0x0Fa0f9990D7969a7aE6f9961d663E4A201Ed6417 (20250121-v3-stable-surge/StableSurgeHook) | 0     | {                                                      | N/A        |   N/A    |
+|                             |                                                                                       |       |   "pool": [                                            |            |          |
+|                             |                                                                                       |       |     "0x7F98F42F9550F92DEE91344d6B5Ab11A9FEc2b4E (N/A)" |            |          |
+|                             |                                                                                       |       |   ],                                                   |            |          |
+|                             |                                                                                       |       |   "newSurgeThresholdPercentage": [                     |            |          |
+|                             |                                                                                       |       |     "100000000000000000"                               |            |          |
+|                             |                                                                                       |       |   ]                                                    |            |          |
+|                             |                                                                                       |       | }                                                      |            |          |
+| setMaxSurgeFeePercentage    | 0x0Fa0f9990D7969a7aE6f9961d663E4A201Ed6417 (20250121-v3-stable-surge/StableSurgeHook) | 0     | {                                                      | N/A        |   N/A    |
+|                             |                                                                                       |       |   "pool": [                                            |            |          |
+|                             |                                                                                       |       |     "0xc2B0D1A1B4cdDA10185859B5a5c543024c2df869 (N/A)" |            |          |
+|                             |                                                                                       |       |   ],                                                   |            |          |
+|                             |                                                                                       |       |   "newMaxSurgeSurgeFeePercentage": [                   |            |          |
+|                             |                                                                                       |       |     "50000000000000000"                                |            |          |
+|                             |                                                                                       |       |   ]                                                    |            |          |
+|                             |                                                                                       |       | }                                                      |            |          |
+| setSurgeThresholdPercentage | 0x0Fa0f9990D7969a7aE6f9961d663E4A201Ed6417 (20250121-v3-stable-surge/StableSurgeHook) | 0     | {                                                      | N/A        |   N/A    |
+|                             |                                                                                       |       |   "pool": [                                            |            |          |
+|                             |                                                                                       |       |     "0xc2B0D1A1B4cdDA10185859B5a5c543024c2df869 (N/A)" |            |          |
+|                             |                                                                                       |       |   ],                                                   |            |          |
+|                             |                                                                                       |       |   "newSurgeThresholdPercentage": [                     |            |          |
+|                             |                                                                                       |       |     "50000000000000000"                                |            |          |
+|                             |                                                                                       |       |   ]                                                    |            |          |
+|                             |                                                                                       |       | }                                                      |            |          |
+| setMaxSurgeFeePercentage    | 0x0Fa0f9990D7969a7aE6f9961d663E4A201Ed6417 (20250121-v3-stable-surge/StableSurgeHook) | 0     | {                                                      | N/A        |   N/A    |
+|                             |                                                                                       |       |   "pool": [                                            |            |          |
+|                             |                                                                                       |       |     "0x19B001e6Bc2d89154c18e2216eec5C8c6047b6d8 (N/A)" |            |          |
+|                             |                                                                                       |       |   ],                                                   |            |          |
+|                             |                                                                                       |       |   "newMaxSurgeSurgeFeePercentage": [                   |            |          |
+|                             |                                                                                       |       |     "50000000000000000"                                |            |          |
+|                             |                                                                                       |       |   ]                                                    |            |          |
+|                             |                                                                                       |       | }                                                      |            |          |
+| setSurgeThresholdPercentage | 0x0Fa0f9990D7969a7aE6f9961d663E4A201Ed6417 (20250121-v3-stable-surge/StableSurgeHook) | 0     | {                                                      | N/A        |   N/A    |
+|                             |                                                                                       |       |   "pool": [                                            |            |          |
+|                             |                                                                                       |       |     "0x19B001e6Bc2d89154c18e2216eec5C8c6047b6d8 (N/A)" |            |          |
+|                             |                                                                                       |       |   ],                                                   |            |          |
+|                             |                                                                                       |       |   "newSurgeThresholdPercentage": [                     |            |          |
+|                             |                                                                                       |       |     "50000000000000000"                                |            |          |
+|                             |                                                                                       |       |   ]                                                    |            |          |
+|                             |                                                                                       |       | }                                                      |            |          |
++-----------------------------+---------------------------------------------------------------------------------------+-------+--------------------------------------------------------+------------+----------+
+```

--- a/MaxiOps/PoolParameterChanges/PoolStableSurgeParams/Base/aGHO-aUSDC-MaxFee-Threshold-Update.json
+++ b/MaxiOps/PoolParameterChanges/PoolStableSurgeParams/Base/aGHO-aUSDC-MaxFee-Threshold-Update.json
@@ -1,0 +1,57 @@
+{
+  "version": "1.0",
+  "chainId": "8453",
+  "createdAt": 1739310695883,
+  "meta": {
+    "name": "Transactions Batch",
+    "description": "",
+    "txBuilderVersion": "1.18.0",
+    "createdFromSafeAddress": "0x9ff471F9f98F42E5151C7855fD1b5aa906b1AF7e",
+    "createdFromOwnerAddress": "",
+    "checksum": "0xe2cee5a803bba2ec6d09200a261516c84e3d3dc99abb2d541f959103489b044c"
+  },
+  "transactions": [
+    {
+      "to": "0xb2007B8B7E0260042517f635CFd8E6dD2Dd7f007",
+      "value": "0",
+      "data": null,
+      "contractMethod": {
+        "inputs": [
+          { "internalType": "address", "name": "pool", "type": "address" },
+          {
+            "internalType": "uint256",
+            "name": "newMaxSurgeSurgeFeePercentage",
+            "type": "uint256"
+          }
+        ],
+        "name": "setMaxSurgeFeePercentage",
+        "payable": false
+      },
+      "contractInputsValues": {
+        "pool": "0x7AB124EC4029316c2A42F713828ddf2a192B36db",
+        "newMaxSurgeSurgeFeePercentage": "100000000000000000"
+      }
+    },
+    {
+      "to": "0xb2007B8B7E0260042517f635CFd8E6dD2Dd7f007",
+      "value": "0",
+      "data": null,
+      "contractMethod": {
+        "inputs": [
+          { "internalType": "address", "name": "pool", "type": "address" },
+          {
+            "internalType": "uint256",
+            "name": "newSurgeThresholdPercentage",
+            "type": "uint256"
+          }
+        ],
+        "name": "setSurgeThresholdPercentage",
+        "payable": false
+      },
+      "contractInputsValues": {
+        "pool": "0x7AB124EC4029316c2A42F713828ddf2a192B36db",
+        "newSurgeThresholdPercentage": "100000000000000000"
+      }
+    }
+  ]
+}

--- a/MaxiOps/PoolParameterChanges/PoolStableSurgeParams/Base/aGHO-aUSDC-MaxFee-Threshold-Update.report.txt
+++ b/MaxiOps/PoolParameterChanges/PoolStableSurgeParams/Base/aGHO-aUSDC-MaxFee-Threshold-Update.report.txt
@@ -1,0 +1,28 @@
+FILENAME: `MaxiOps/PoolParameterChanges/PoolStableSurgeParams/Base/aGHO-aUSDC-MaxFee-Threshold-Update.json`
+MULTISIG: `multisigs/maxi_omni (base:0x9ff471F9f98F42E5151C7855fD1b5aa906b1AF7e)`
+COMMIT: `e8d80eb702582ac9ed567b6bfb44b1a41b82286b`
+CHAIN(S): `base`
+TENDERLY: [`🟩 SUCCESS`](https://www.tdly.co/shared/simulation/f3ef44ff-9b38-4786-be59-6a6978f70abf)
+
+```
++-----------------------------+---------------------------------------------------------------------------------------+-------+--------------------------------------------------------+------------+----------+
+| fx_name                     | to                                                                                    | value | inputs                                                 | bip_number | tx_index |
++-----------------------------+---------------------------------------------------------------------------------------+-------+--------------------------------------------------------+------------+----------+
+| setMaxSurgeFeePercentage    | 0xb2007B8B7E0260042517f635CFd8E6dD2Dd7f007 (20250121-v3-stable-surge/StableSurgeHook) | 0     | {                                                      | N/A        |   N/A    |
+|                             |                                                                                       |       |   "pool": [                                            |            |          |
+|                             |                                                                                       |       |     "0x7AB124EC4029316c2A42F713828ddf2a192B36db (N/A)" |            |          |
+|                             |                                                                                       |       |   ],                                                   |            |          |
+|                             |                                                                                       |       |   "newMaxSurgeSurgeFeePercentage": [                   |            |          |
+|                             |                                                                                       |       |     "100000000000000000"                               |            |          |
+|                             |                                                                                       |       |   ]                                                    |            |          |
+|                             |                                                                                       |       | }                                                      |            |          |
+| setSurgeThresholdPercentage | 0xb2007B8B7E0260042517f635CFd8E6dD2Dd7f007 (20250121-v3-stable-surge/StableSurgeHook) | 0     | {                                                      | N/A        |   N/A    |
+|                             |                                                                                       |       |   "pool": [                                            |            |          |
+|                             |                                                                                       |       |     "0x7AB124EC4029316c2A42F713828ddf2a192B36db (N/A)" |            |          |
+|                             |                                                                                       |       |   ],                                                   |            |          |
+|                             |                                                                                       |       |   "newSurgeThresholdPercentage": [                     |            |          |
+|                             |                                                                                       |       |     "100000000000000000"                               |            |          |
+|                             |                                                                                       |       |   ]                                                    |            |          |
+|                             |                                                                                       |       | }                                                      |            |          |
++-----------------------------+---------------------------------------------------------------------------------------+-------+--------------------------------------------------------+------------+----------+
+```

--- a/MaxiOps/PoolParameterChanges/PoolStableSurgeParams/Mainnet/StableSurge-LaunchPools-config.json
+++ b/MaxiOps/PoolParameterChanges/PoolStableSurgeParams/Mainnet/StableSurge-LaunchPools-config.json
@@ -1,0 +1,141 @@
+{
+  "version": "1.0",
+  "chainId": "1",
+  "createdAt": 1739310159822,
+  "meta": {
+    "name": "Transactions Batch",
+    "description": "",
+    "txBuilderVersion": "1.18.0",
+    "createdFromSafeAddress": "0x9ff471F9f98F42E5151C7855fD1b5aa906b1AF7e",
+    "createdFromOwnerAddress": "",
+    "checksum": "0xbffc03f48f6696e5b362ae788ec06d7f30553c54decd44ef71cedb40b3790b7f"
+  },
+  "transactions": [
+    {
+      "to": "0xb18fA0cb5DE8cecB8899AAE6e38b1B7ed77885dA",
+      "value": "0",
+      "data": null,
+      "contractMethod": {
+        "inputs": [
+          { "internalType": "address", "name": "pool", "type": "address" },
+          {
+            "internalType": "uint256",
+            "name": "newSurgeThresholdPercentage",
+            "type": "uint256"
+          }
+        ],
+        "name": "setSurgeThresholdPercentage",
+        "payable": false
+      },
+      "contractInputsValues": {
+        "pool": "0x2b261C98A81cfda61BeE7BFcf941A3D336be7957",
+        "newSurgeThresholdPercentage": "100000000000000000"
+      }
+    },
+    {
+      "to": "0xb18fA0cb5DE8cecB8899AAE6e38b1B7ed77885dA",
+      "value": "0",
+      "data": null,
+      "contractMethod": {
+        "inputs": [
+          { "internalType": "address", "name": "pool", "type": "address" },
+          {
+            "internalType": "uint256",
+            "name": "newMaxSurgeSurgeFeePercentage",
+            "type": "uint256"
+          }
+        ],
+        "name": "setMaxSurgeFeePercentage",
+        "payable": false
+      },
+      "contractInputsValues": {
+        "pool": "0x2b261C98A81cfda61BeE7BFcf941A3D336be7957",
+        "newMaxSurgeSurgeFeePercentage": "50000000000000000"
+      }
+    },
+    {
+      "to": "0xb18fA0cb5DE8cecB8899AAE6e38b1B7ed77885dA",
+      "value": "0",
+      "data": null,
+      "contractMethod": {
+        "inputs": [
+          { "internalType": "address", "name": "pool", "type": "address" },
+          {
+            "internalType": "uint256",
+            "name": "newSurgeThresholdPercentage",
+            "type": "uint256"
+          }
+        ],
+        "name": "setSurgeThresholdPercentage",
+        "payable": false
+      },
+      "contractInputsValues": {
+        "pool": "0x9ED5175aeCB6653C1BDaa19793c16fd74fBeEB37",
+        "newSurgeThresholdPercentage": "100000000000000000"
+      }
+    },
+    {
+      "to": "0xb18fA0cb5DE8cecB8899AAE6e38b1B7ed77885dA",
+      "value": "0",
+      "data": null,
+      "contractMethod": {
+        "inputs": [
+          { "internalType": "address", "name": "pool", "type": "address" },
+          {
+            "internalType": "uint256",
+            "name": "newMaxSurgeSurgeFeePercentage",
+            "type": "uint256"
+          }
+        ],
+        "name": "setMaxSurgeFeePercentage",
+        "payable": false
+      },
+      "contractInputsValues": {
+        "pool": "0x9ED5175aeCB6653C1BDaa19793c16fd74fBeEB37",
+        "newMaxSurgeSurgeFeePercentage": "50000000000000000"
+      }
+    },
+    {
+      "to": "0xb18fA0cb5DE8cecB8899AAE6e38b1B7ed77885dA",
+      "value": "0",
+      "data": null,
+      "contractMethod": {
+        "inputs": [
+          { "internalType": "address", "name": "pool", "type": "address" },
+          {
+            "internalType": "uint256",
+            "name": "newSurgeThresholdPercentage",
+            "type": "uint256"
+          }
+        ],
+        "name": "setSurgeThresholdPercentage",
+        "payable": false
+      },
+      "contractInputsValues": {
+        "pool": "0x2Bd57acd9f52A8d323a088a072A805108BF015A2",
+        "newSurgeThresholdPercentage": "50000000000000000"
+      }
+    },
+    {
+      "to": "0xb18fA0cb5DE8cecB8899AAE6e38b1B7ed77885dA",
+      "value": "0",
+      "data": null,
+      "contractMethod": {
+        "inputs": [
+          { "internalType": "address", "name": "pool", "type": "address" },
+          {
+            "internalType": "uint256",
+            "name": "newMaxSurgeSurgeFeePercentage",
+            "type": "uint256"
+          }
+        ],
+        "name": "setMaxSurgeFeePercentage",
+        "payable": false
+      },
+      "contractInputsValues": {
+        "pool": "0x2Bd57acd9f52A8d323a088a072A805108BF015A2",
+        "newMaxSurgeSurgeFeePercentage": "50000000000000000"
+      }
+    }
+  ]
+}

--- a/MaxiOps/PoolParameterChanges/PoolStableSurgeParams/Mainnet/StableSurge-LaunchPools-config.report.txt
+++ b/MaxiOps/PoolParameterChanges/PoolStableSurgeParams/Mainnet/StableSurge-LaunchPools-config.report.txt
@@ -1,0 +1,60 @@
+FILENAME: `MaxiOps/PoolParameterChanges/PoolStableSurgeParams/Mainnet/StableSurge-LaunchPools-config.json`
+MULTISIG: `multisigs/maxi_omni (mainnet:0x9ff471F9f98F42E5151C7855fD1b5aa906b1AF7e)`
+COMMIT: `e8d80eb702582ac9ed567b6bfb44b1a41b82286b`
+CHAIN(S): `mainnet`
+TENDERLY: [`🟩 SUCCESS`](https://www.tdly.co/shared/simulation/96d7078d-9090-442e-96bf-65a140a00e11)
+
+```
++-----------------------------+---------------------------------------------------------------------------------------+-------+--------------------------------------------------------+------------+----------+
+| fx_name                     | to                                                                                    | value | inputs                                                 | bip_number | tx_index |
++-----------------------------+---------------------------------------------------------------------------------------+-------+--------------------------------------------------------+------------+----------+
+| setSurgeThresholdPercentage | 0xb18fA0cb5DE8cecB8899AAE6e38b1B7ed77885dA (20250121-v3-stable-surge/StableSurgeHook) | 0     | {                                                      | N/A        |   N/A    |
+|                             |                                                                                       |       |   "pool": [                                            |            |          |
+|                             |                                                                                       |       |     "0x2b261C98A81cfda61BeE7BFcf941A3D336be7957 (N/A)" |            |          |
+|                             |                                                                                       |       |   ],                                                   |            |          |
+|                             |                                                                                       |       |   "newSurgeThresholdPercentage": [                     |            |          |
+|                             |                                                                                       |       |     "100000000000000000"                               |            |          |
+|                             |                                                                                       |       |   ]                                                    |            |          |
+|                             |                                                                                       |       | }                                                      |            |          |
+| setMaxSurgeFeePercentage    | 0xb18fA0cb5DE8cecB8899AAE6e38b1B7ed77885dA (20250121-v3-stable-surge/StableSurgeHook) | 0     | {                                                      | N/A        |   N/A    |
+|                             |                                                                                       |       |   "pool": [                                            |            |          |
+|                             |                                                                                       |       |     "0x2b261C98A81cfda61BeE7BFcf941A3D336be7957 (N/A)" |            |          |
+|                             |                                                                                       |       |   ],                                                   |            |          |
+|                             |                                                                                       |       |   "newMaxSurgeSurgeFeePercentage": [                   |            |          |
+|                             |                                                                                       |       |     "50000000000000000"                                |            |          |
+|                             |                                                                                       |       |   ]                                                    |            |          |
+|                             |                                                                                       |       | }                                                      |            |          |
+| setSurgeThresholdPercentage | 0xb18fA0cb5DE8cecB8899AAE6e38b1B7ed77885dA (20250121-v3-stable-surge/StableSurgeHook) | 0     | {                                                      | N/A        |   N/A    |
+|                             |                                                                                       |       |   "pool": [                                            |            |          |
+|                             |                                                                                       |       |     "0x9ED5175aeCB6653C1BDaa19793c16fd74fBeEB37 (N/A)" |            |          |
+|                             |                                                                                       |       |   ],                                                   |            |          |
+|                             |                                                                                       |       |   "newSurgeThresholdPercentage": [                     |            |          |
+|                             |                                                                                       |       |     "100000000000000000"                               |            |          |
+|                             |                                                                                       |       |   ]                                                    |            |          |
+|                             |                                                                                       |       | }                                                      |            |          |
+| setMaxSurgeFeePercentage    | 0xb18fA0cb5DE8cecB8899AAE6e38b1B7ed77885dA (20250121-v3-stable-surge/StableSurgeHook) | 0     | {                                                      | N/A        |   N/A    |
+|                             |                                                                                       |       |   "pool": [                                            |            |          |
+|                             |                                                                                       |       |     "0x9ED5175aeCB6653C1BDaa19793c16fd74fBeEB37 (N/A)" |            |          |
+|                             |                                                                                       |       |   ],                                                   |            |          |
+|                             |                                                                                       |       |   "newMaxSurgeSurgeFeePercentage": [                   |            |          |
+|                             |                                                                                       |       |     "50000000000000000"                                |            |          |
+|                             |                                                                                       |       |   ]                                                    |            |          |
+|                             |                                                                                       |       | }                                                      |            |          |
+| setSurgeThresholdPercentage | 0xb18fA0cb5DE8cecB8899AAE6e38b1B7ed77885dA (20250121-v3-stable-surge/StableSurgeHook) | 0     | {                                                      | N/A        |   N/A    |
+|                             |                                                                                       |       |   "pool": [                                            |            |          |
+|                             |                                                                                       |       |     "0x2Bd57acd9f52A8d323a088a072A805108BF015A2 (N/A)" |            |          |
+|                             |                                                                                       |       |   ],                                                   |            |          |
+|                             |                                                                                       |       |   "newSurgeThresholdPercentage": [                     |            |          |
+|                             |                                                                                       |       |     "50000000000000000"                                |            |          |
+|                             |                                                                                       |       |   ]                                                    |            |          |
+|                             |                                                                                       |       | }                                                      |            |          |
+| setMaxSurgeFeePercentage    | 0xb18fA0cb5DE8cecB8899AAE6e38b1B7ed77885dA (20250121-v3-stable-surge/StableSurgeHook) | 0     | {                                                      | N/A        |   N/A    |
+|                             |                                                                                       |       |   "pool": [                                            |            |          |
+|                             |                                                                                       |       |     "0x2Bd57acd9f52A8d323a088a072A805108BF015A2 (N/A)" |            |          |
+|                             |                                                                                       |       |   ],                                                   |            |          |
+|                             |                                                                                       |       |   "newMaxSurgeSurgeFeePercentage": [                   |            |          |
+|                             |                                                                                       |       |     "50000000000000000"                                |            |          |
+|                             |                                                                                       |       |   ]                                                    |            |          |
+|                             |                                                                                       |       | }                                                      |            |          |
++-----------------------------+---------------------------------------------------------------------------------------+-------+--------------------------------------------------------+------------+----------+
+```


### PR DESCRIPTION
Initial launch used for testing different pools with 5% or 10% for maxSurgeFee and maxThreshold depending on asset type.

3pools typically should have smaller thresholds due to less room to go off peg. 50% vs 33% for parity require different threshold settings. 5% typically for 3pools. 5-10% being tested for 2pools. 

Max fee settings of 5 and 10% being utilized. Potentially both are too aggressive but we will see if they create to much friction or perform well. Can see potential for lower amounts such as 10 - 100x the baseFee making more sense. This would range from 0.05-4% in most cases as 0.005-0.04 are typical are stable pools.