### PR TITLE
Add-USDC-Injector-SurgePools-Base-Arbitrum

### DIFF
--- a/MaxiOps/add_rewards/arbitrum/StableSurge-USDC-injections-V3LaunchPlan.json
+++ b/MaxiOps/add_rewards/arbitrum/StableSurge-USDC-injections-V3LaunchPlan.json
@@ -1,0 +1,90 @@
+{
+  "version": "1.0",
+  "chainId": "42161",
+  "createdAt": 1739380421508,
+  "meta": {
+    "name": "Transactions Batch",
+    "description": "",
+    "txBuilderVersion": "1.16.5",
+    "createdFromSafeAddress": "0xc38c5f97B34E175FFd35407fc91a937300E33860",
+    "createdFromOwnerAddress": "",
+    "checksum": "0x90f4c82078ec24e1c5389807a2084a2e7a3c9904d86f418ef33e7b6a67722ee5"
+  },
+  "transactions": [
+    {
+      "to": "0x97207B095e4D5C9a6e4cfbfcd2C3358E03B90c4A",
+      "value": "0",
+      "data": null,
+      "contractMethod": {
+        "inputs": [
+          {
+            "internalType": "address",
+            "name": "target",
+            "type": "address"
+          },
+          {
+            "internalType": "bytes",
+            "name": "data",
+            "type": "bytes"
+          }
+        ],
+        "name": "performAction",
+        "payable": true
+      },
+      "contractInputsValues": {
+        "target": "0x915475b32983b7eb1235c1b6752149b454f81ad8",
+        "data": "0xe8de0d4d000000000000000000000000af88d065e77c8cC2239327C5EDb3A432268e5831000000000000000000000000abC414cEE2F6E8Ee262d6dc106c86A3f627f84D2"
+      }
+    },
+    {
+      "to": "0x97207B095e4D5C9a6e4cfbfcd2C3358E03B90c4A",
+      "value": "0",
+      "data": null,
+      "contractMethod": {
+        "inputs": [
+          {
+            "internalType": "address",
+            "name": "target",
+            "type": "address"
+          },
+          {
+            "internalType": "bytes",
+            "name": "data",
+            "type": "bytes"
+          }
+        ],
+        "name": "performAction",
+        "payable": true
+      },
+      "contractInputsValues": {
+        "target": "0x9419c8b7ff370db3823164acea6d9664f4b9c8a9",
+        "data": "0xe8de0d4d000000000000000000000000af88d065e77c8cC2239327C5EDb3A432268e5831000000000000000000000000abC414cEE2F6E8Ee262d6dc106c86A3f627f84D2"
+      }
+    },
+    {
+      "to": "0x97207B095e4D5C9a6e4cfbfcd2C3358E03B90c4A",
+      "value": "0",
+      "data": null,
+      "contractMethod": {
+        "inputs": [
+          {
+            "internalType": "address",
+            "name": "target",
+            "type": "address"
+          },
+          {
+            "internalType": "bytes",
+            "name": "data",
+            "type": "bytes"
+          }
+        ],
+        "name": "performAction",
+        "payable": true
+      },
+      "contractInputsValues": {
+        "target": "0xfb7a403481c0bfcb7c3848a1f8f848f0f7d61cd4",
+        "data": "0xe8de0d4d000000000000000000000000af88d065e77c8cC2239327C5EDb3A432268e5831000000000000000000000000abC414cEE2F6E8Ee262d6dc106c86A3f627f84D2"
+      }
+    }
+  ]
+}

--- a/MaxiOps/add_rewards/base/GHO-USDC-StableSurge-V3Launch-USDC.json
+++ b/MaxiOps/add_rewards/base/GHO-USDC-StableSurge-V3Launch-USDC.json
@@ -1,0 +1,32 @@
+{
+  "version": "1.0",
+  "chainId": "8453",
+  "createdAt": 1739379890321,
+  "meta": {
+    "name": "Transactions Batch",
+    "description": "",
+    "txBuilderVersion": "1.18.0",
+    "createdFromSafeAddress": "0x65226673F3D202E0f897C862590d7e1A992B2048",
+    "createdFromOwnerAddress": "",
+    "checksum": "0xdf4df21ffb073c6c5f5e54a665565f4794ed045e4c471bbb258272fe057bbca8"
+  },
+  "transactions": [
+    {
+      "to": "0x9129E834e15eA19b6069e8f08a8EcFc13686B8dC",
+      "value": "0",
+      "data": null,
+      "contractMethod": {
+        "inputs": [
+          { "internalType": "address", "name": "target", "type": "address" },
+          { "internalType": "bytes", "name": "data", "type": "bytes" }
+        ],
+        "name": "performAction",
+        "payable": true
+      },
+      "contractInputsValues": {
+        "target": "0x70db188e5953f67a4b16979a2cea26248b315401",
+        "data": "0xe8de0d4d000000000000000000000000833589fCD6eDb6E08f4c7C32D4f71b54bdA02913000000000000000000000000A6E7840Fc8193cFeBDdf177fa410038E5DD08f7A"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Adding USDC as a reward token with injectors as distributors for

Arbitrum
- aGHO-aUSDC-aUSDT (https://balancer.fi/pools/arbitrum/v3/0x19B001e6Bc2d89154c18e2216eec5C8c6047b6d8)
- sUSDX-USDX-aUSDT (https://balancer.fi/pools/arbitrum/v3/0xc2B0D1A1B4cdDA10185859B5a5c543024c2df869)
- tETH-Aave weETH (https://balancer.fi/pools/arbitrum/v3/0x7F98F42F9550F92DEE91344d6B5Ab11A9FEc2b4E) Base
- aGHO-aUSDC (https://balancer.fi/pools/base/v3/0x7AB124EC4029316c2A42F713828ddf2a192B36db)