### PR TITLE
Add voting data for 2025-W9

### DIFF
--- a/MaxiOps/vlaura_voting/2025/W9/input/BD Vote Template - February 12 2025.csv
+++ b/MaxiOps/vlaura_voting/2025/W9/input/BD Vote Template - February 12 2025.csv
@@ -1,0 +1,42 @@
+Chain,Label,Gauge Address,Allocation %,,,,
+Mainnet,Aave USDC USDT,0xeec405b834c90b59122bcc2357f27110b2adb4b7,5.00%,Core Liquidity,,,
+Mainnet,V3 GHO/USDC/USDT,0x9fdD52eFEb601E4Bc78b89C6490505B8aC637E9f,10.00%,,,,
+Mainnet,Lido wstETH wETH,0x4b891340b51889f438a03dc0e8aaafb0bc89e7a6,15.00%,,,,
+Mainnet ,csUSDL-csUSDC,0x5bbaed1fadc08c5fb3e4ae3c8848777e2da77103,10.00%,,,,
+Mainnet,rstETH-Lido wstETH,0x04202b147eae6f5f50cbf72d0b8e9459c57b15e6,5.00%,,,,
+Mainnet,pxETH-gtWETHe,0x3a51bdf9013633ae934a3630db96f09ae4c5814a,5.00%,50.00%,Dinero Round 2 of 2,,wdyt about 7.5% or more?
+Mainnet,50wstETH/ACX,0xf7b0751fea697cf1a541a5f57d11058a8fb794ee,1.39%,Revenue ,,,no ^
+Mainnet,wstETH-wETH-BPT,0x5c0f23a5c1be65fa710d385814a7fd1bda480b1c,6.16%,20.00%,,,
+Mainnet,B-rETH-Stable,0x79ef6103a513951a3b25743db509e267685726b7 ,2.93%,,,,
+Base,rETH-wETH,0xd75026F8723b94d9a360A282080492d905c6A558,7.20%,,,,
+Mainnet,ezETH-wETH,0xa8b309a75f0d64ed632d45a003c68a30e59a1d8b,2.32%,,,,
+,,,,20.00%,,,
+,,,,Biz Dev,,,
+Base,Aave wETH-wstETH,0x0855e486EE80FF0EC7c913eC0588A7CBf2B8E89c,6.00%,,Nothing promised afaik,,"USDC starts tomorrow, can do"
+Base,Aave ezETH-wstETH,0x86C44de72Ec88d205E63c2aF8D577659319C7a7f,5.00%,,Nothing promised afaik,,"USDC starts tomorrow, can do"
+Base,sUSDs / seamlessUSDC,0x53D051F583D418DE6512db1Bde281957F043937b,5.00%,,Promised 5% for 1 epoch then re-evaluate after,,"USDC starts tomorrow, can do"
+Arbitrum,Aave wETH-wstETH,0xB2FcAd9fd42Affd0A90a996A1DEde4427435e5F8,6.00%,,Nothing promised afaik,,"USDC 1 week ago, can do"
+Arbitrum,Aave ezETH-wstETH,0xCA318253Bb460e08ca33fD22574E7F70217130f5,5.00%,,Nothing promised afaik,,"USDC 1 week ago, can do"
+Arbitrum,Aave USDC-yUSD,0x9172ad6A79cd6a25F60b1312262ec51219e05f6d,3.00%,,Nothing promised afaik,,"Idk these guys are vague, we can carry them on with small USDC bag or cut. WDYT maybe just this an no usdc for 1 round?"
+,,,,30%,,,
+,,,,TOTAL,,,
+,,,,100.00%,,,
+,,,,,,,
+,,,,,,,
+,,,,,,,
+,,,,,,,
+,,,,,,,
+,,,,,,,
+,,,,,,,
+,,,,,,,
+,,1200,,,,,
+,,100000,,,,,
+,,"$16,666.67",,,,,
+,,14,,,,,
+,,,,,,,
+Total USDC,"$100,000",,,,,,
+APY needed,6%,,,,,,
+Incentives per 1m,60000,,,,,,
+Incentives per wk,"$1,154",,,,,,
+Incentives per 6 wks,"$4,615",,,,,,
+Total TVL to support,22,,,,,,


### PR DESCRIPTION
Add voting data for 2025-W9

Based on this sheet, hope comments on right are not a problem 
https://docs.google.com/spreadsheets/d/1w63dyNGi0IB_bXgGXQk2lwknnT5wxCUkKHVp5bHqlFc/edit?gid=621469694#gid=621469694

Top revenue earners based on this data, 20% to top 5 to lean into V3 further.
https://github.com/BalancerMaxis/protocol_fee_allocator/blob/04b87cb8108eac7cae1e1515ec6fd8d3a833066c/fee_allocator/allocations/incentives_2025-01-30_2025-02-13.csv