### PR TITLE
chore: add payload for sonic dao msig setup

### DIFF
--- a/MaxiOps/signers/dao-sonic.json
+++ b/MaxiOps/signers/dao-sonic.json
@@ -1,0 +1,180 @@
+{
+  "version": "1.0",
+  "chainId": "146",
+  "createdAt": 1739794864755,
+  "meta": {
+    "name": "Transactions Batch",
+    "description": "",
+    "txBuilderVersion": "1.18.0",
+    "createdFromSafeAddress": "0x4f22C2784Cbd2B24a172566491Ee73fee1A63c2e",
+    "createdFromOwnerAddress": "",
+    "checksum": "0xa5ead990c00623cc0fc1f7c5841dc04cb847f3e48ccedf55b6d2f72b7cdcca51"
+  },
+  "transactions": [
+    {
+      "to": "0x4f22C2784Cbd2B24a172566491Ee73fee1A63c2e",
+      "value": "0",
+      "data": null,
+      "contractMethod": {
+        "inputs": [
+          { "internalType": "address", "name": "prevOwner", "type": "address" },
+          { "internalType": "address", "name": "oldOwner", "type": "address" },
+          { "internalType": "address", "name": "newOwner", "type": "address" }
+        ],
+        "name": "swapOwner",
+        "payable": false
+      },
+      "contractInputsValues": {
+        "prevOwner": "0x11761c7b08287d9489CD84C04DF6852F5C07107b",
+        "oldOwner": "0x200550cAD164E8e0Cb544A9c7Dc5c833122C1438",
+        "newOwner": "0xA39a62304d8d43B35114ad7bd1258B0E50e139b3"
+      }
+    },
+    {
+      "to": "0x4f22C2784Cbd2B24a172566491Ee73fee1A63c2e",
+      "value": "0",
+      "data": null,
+      "contractMethod": {
+        "inputs": [
+          { "internalType": "address", "name": "prevOwner", "type": "address" },
+          { "internalType": "address", "name": "oldOwner", "type": "address" },
+          { "internalType": "address", "name": "newOwner", "type": "address" }
+        ],
+        "name": "swapOwner",
+        "payable": false
+      },
+      "contractInputsValues": {
+        "prevOwner": "0xA39a62304d8d43B35114ad7bd1258B0E50e139b3",
+        "oldOwner": "0x7019Be4E4eB74cA5F61224FeAf687d2b43998516",
+        "newOwner": "0x59693BA1A5764e087CE166ac0E0085Fc071B9ea7"
+      }
+    },
+    {
+      "to": "0x4f22C2784Cbd2B24a172566491Ee73fee1A63c2e",
+      "value": "0",
+      "data": null,
+      "contractMethod": {
+        "inputs": [
+          { "internalType": "address", "name": "prevOwner", "type": "address" },
+          { "internalType": "address", "name": "oldOwner", "type": "address" },
+          { "internalType": "address", "name": "newOwner", "type": "address" }
+        ],
+        "name": "swapOwner",
+        "payable": false
+      },
+      "contractInputsValues": {
+        "prevOwner": "0x59693BA1A5764e087CE166ac0E0085Fc071B9ea7",
+        "oldOwner": "0xc4591c41e01a7a654B5427f39Bbd1dEe5bD45D1D",
+        "newOwner": "0x3ABDc84Dd15b0058B281D7e26CCc3932cfb268aA"
+      }
+    },
+    {
+      "to": "0x4f22C2784Cbd2B24a172566491Ee73fee1A63c2e",
+      "value": "0",
+      "data": null,
+      "contractMethod": {
+        "inputs": [
+          { "internalType": "address", "name": "prevOwner", "type": "address" },
+          { "internalType": "address", "name": "oldOwner", "type": "address" },
+          { "internalType": "address", "name": "newOwner", "type": "address" }
+        ],
+        "name": "swapOwner",
+        "payable": false
+      },
+      "contractInputsValues": {
+        "prevOwner": "0x3ABDc84Dd15b0058B281D7e26CCc3932cfb268aA",
+        "oldOwner": "0xafFC70b81D54F229A5F50ec07e2c76D2AAAD07Ae",
+        "newOwner": "0x0951FF0835302929d6c0162b3d2495A85e38ec3A"
+      }
+    },
+    {
+      "to": "0x4f22C2784Cbd2B24a172566491Ee73fee1A63c2e",
+      "value": "0",
+      "data": null,
+      "contractMethod": {
+        "inputs": [
+          { "internalType": "address", "name": "prevOwner", "type": "address" },
+          { "internalType": "address", "name": "oldOwner", "type": "address" },
+          { "internalType": "address", "name": "newOwner", "type": "address" }
+        ],
+        "name": "swapOwner",
+        "payable": false
+      },
+      "contractInputsValues": {
+        "prevOwner": "0x0951FF0835302929d6c0162b3d2495A85e38ec3A",
+        "oldOwner": "0x7c2eA10D3e5922ba3bBBafa39Dc0677353D2AF17",
+        "newOwner": "0x823DF0278e4998cD0D06FB857fBD51e85b18A250"
+      }
+    },
+    {
+      "to": "0x4f22C2784Cbd2B24a172566491Ee73fee1A63c2e",
+      "value": "0",
+      "data": null,
+      "contractMethod": {
+        "inputs": [
+          { "internalType": "address", "name": "prevOwner", "type": "address" },
+          { "internalType": "address", "name": "oldOwner", "type": "address" },
+          { "internalType": "address", "name": "newOwner", "type": "address" }
+        ],
+        "name": "swapOwner",
+        "payable": false
+      },
+      "contractInputsValues": {
+        "prevOwner": "0x823DF0278e4998cD0D06FB857fBD51e85b18A250",
+        "oldOwner": "0x512fce9B07Ce64590849115EE6B32fd40eC0f5F3",
+        "newOwner": "0xAc1aA53108712d7f38093A67d380aD54B562a650"
+      }
+    },
+    {
+      "to": "0x4f22C2784Cbd2B24a172566491Ee73fee1A63c2e",
+      "value": "0",
+      "data": null,
+      "contractMethod": {
+        "inputs": [
+          { "internalType": "address", "name": "owner", "type": "address" },
+          { "internalType": "uint256", "name": "_threshold", "type": "uint256" }
+        ],
+        "name": "addOwnerWithThreshold",
+        "payable": false
+      },
+      "contractInputsValues": {
+        "owner": "0x9F7dfAb2222A473284205cdDF08a677726d786A0",
+        "_threshold": "6"
+      }
+    },
+    {
+      "to": "0x4f22C2784Cbd2B24a172566491Ee73fee1A63c2e",
+      "value": "0",
+      "data": null,
+      "contractMethod": {
+        "inputs": [
+          { "internalType": "address", "name": "owner", "type": "address" },
+          { "internalType": "uint256", "name": "_threshold", "type": "uint256" }
+        ],
+        "name": "addOwnerWithThreshold",
+        "payable": false
+      },
+      "contractInputsValues": {
+        "owner": "0x9BE6ff2A1D5139Eda96339E2644dC1F05d803600",
+        "_threshold": "6"
+      }
+    },
+    {
+      "to": "0x4f22C2784Cbd2B24a172566491Ee73fee1A63c2e",
+      "value": "0",
+      "data": null,
+      "contractMethod": {
+        "inputs": [
+          { "internalType": "address", "name": "owner", "type": "address" },
+          { "internalType": "uint256", "name": "_threshold", "type": "uint256" }
+        ],
+        "name": "addOwnerWithThreshold",
+        "payable": false
+      },
+      "contractInputsValues": {
+        "owner": "0x285b7EEa81a5B66B62e7276a24c1e0F83F7409c1",
+        "_threshold": "6"
+      }
+    }
+  ]
+}

--- a/MaxiOps/signers/dao-sonic.report.txt
+++ b/MaxiOps/signers/dao-sonic.report.txt
@@ -1,0 +1,102 @@
+FILENAME: `MaxiOps/signers/dao-sonic.json`
+MULTISIG: `multisigs/dao (sonic:0x4f22C2784Cbd2B24a172566491Ee73fee1A63c2e)`
+COMMIT: `cd8d8f94ee427bab32920a782ee56efd65c59b15`
+CHAIN(S): `sonic`
+TENDERLY: [`🟩 SUCCESS`](https://www.tdly.co/shared/simulation/ccd0536d-105a-4ff0-8bee-cd0233188a23)
+
+```
++-----------------------+------------------------------------------------------------+-------+-------------------------------------------------------------------------------------+------------+----------+
+| fx_name               | to                                                         | value | inputs                                                                              | bip_number | tx_index |
++-----------------------+------------------------------------------------------------+-------+-------------------------------------------------------------------------------------+------------+----------+
+| swapOwner             | 0x4f22C2784Cbd2B24a172566491Ee73fee1A63c2e (multisigs/dao) | 0     | {                                                                                   | N/A        |   N/A    |
+|                       |                                                            |       |   "prevOwner": [                                                                    |            |          |
+|                       |                                                            |       |     "0x11761c7b08287d9489CD84C04DF6852F5C07107b (EOA/maxis/gosuto)"                 |            |          |
+|                       |                                                            |       |   ],                                                                                |            |          |
+|                       |                                                            |       |   "oldOwner": [                                                                     |            |          |
+|                       |                                                            |       |     "0x200550cAD164E8e0Cb544A9c7Dc5c833122C1438 (EOA/maxis/danko)"                  |            |          |
+|                       |                                                            |       |   ],                                                                                |            |          |
+|                       |                                                            |       |   "newOwner": [                                                                     |            |          |
+|                       |                                                            |       |     "0xA39a62304d8d43B35114ad7bd1258B0E50e139b3 (EOA/dao/eboadom)"                  |            |          |
+|                       |                                                            |       |   ]                                                                                 |            |          |
+|                       |                                                            |       | }                                                                                   |            |          |
+| swapOwner             | 0x4f22C2784Cbd2B24a172566491Ee73fee1A63c2e (multisigs/dao) | 0     | {                                                                                   | N/A        |   N/A    |
+|                       |                                                            |       |   "prevOwner": [                                                                    |            |          |
+|                       |                                                            |       |     "0xA39a62304d8d43B35114ad7bd1258B0E50e139b3 (EOA/dao/eboadom)"                  |            |          |
+|                       |                                                            |       |   ],                                                                                |            |          |
+|                       |                                                            |       |   "oldOwner": [                                                                     |            |          |
+|                       |                                                            |       |     "0x7019Be4E4eB74cA5F61224FeAf687d2b43998516 (EOA/emergency/xeonus)"             |            |          |
+|                       |                                                            |       |   ],                                                                                |            |          |
+|                       |                                                            |       |   "newOwner": [                                                                     |            |          |
+|                       |                                                            |       |     "0x59693BA1A5764e087CE166ac0E0085Fc071B9ea7 (EOA/dao/0xSausageDoge)"            |            |          |
+|                       |                                                            |       |   ]                                                                                 |            |          |
+|                       |                                                            |       | }                                                                                   |            |          |
+| swapOwner             | 0x4f22C2784Cbd2B24a172566491Ee73fee1A63c2e (multisigs/dao) | 0     | {                                                                                   | N/A        |   N/A    |
+|                       |                                                            |       |   "prevOwner": [                                                                    |            |          |
+|                       |                                                            |       |     "0x59693BA1A5764e087CE166ac0E0085Fc071B9ea7 (EOA/dao/0xSausageDoge)"            |            |          |
+|                       |                                                            |       |   ],                                                                                |            |          |
+|                       |                                                            |       |   "oldOwner": [                                                                     |            |          |
+|                       |                                                            |       |     "0xc4591c41e01a7a654B5427f39Bbd1dEe5bD45D1D (EOA/maxi_deployers/mikeb)"         |            |          |
+|                       |                                                            |       |   ],                                                                                |            |          |
+|                       |                                                            |       |   "newOwner": [                                                                     |            |          |
+|                       |                                                            |       |     "0x3ABDc84Dd15b0058B281D7e26CCc3932cfb268aA (EOA/dao/AlexLangeVC)"              |            |          |
+|                       |                                                            |       |   ]                                                                                 |            |          |
+|                       |                                                            |       | }                                                                                   |            |          |
+| swapOwner             | 0x4f22C2784Cbd2B24a172566491Ee73fee1A63c2e (multisigs/dao) | 0     | {                                                                                   | N/A        |   N/A    |
+|                       |                                                            |       |   "prevOwner": [                                                                    |            |          |
+|                       |                                                            |       |     "0x3ABDc84Dd15b0058B281D7e26CCc3932cfb268aA (EOA/dao/AlexLangeVC)"              |            |          |
+|                       |                                                            |       |   ],                                                                                |            |          |
+|                       |                                                            |       |   "oldOwner": [                                                                     |            |          |
+|                       |                                                            |       |     "0xafFC70b81D54F229A5F50ec07e2c76D2AAAD07Ae (EOA/contributors-payees/zekraken)" |            |          |
+|                       |                                                            |       |   ],                                                                                |            |          |
+|                       |                                                            |       |   "newOwner": [                                                                     |            |          |
+|                       |                                                            |       |     "0x0951FF0835302929d6c0162b3d2495A85e38ec3A (EOA/dao/mounibec)"                 |            |          |
+|                       |                                                            |       |   ]                                                                                 |            |          |
+|                       |                                                            |       | }                                                                                   |            |          |
+| swapOwner             | 0x4f22C2784Cbd2B24a172566491Ee73fee1A63c2e (multisigs/dao) | 0     | {                                                                                   | N/A        |   N/A    |
+|                       |                                                            |       |   "prevOwner": [                                                                    |            |          |
+|                       |                                                            |       |     "0x0951FF0835302929d6c0162b3d2495A85e38ec3A (EOA/dao/mounibec)"                 |            |          |
+|                       |                                                            |       |   ],                                                                                |            |          |
+|                       |                                                            |       |   "oldOwner": [                                                                     |            |          |
+|                       |                                                            |       |     "0x7c2eA10D3e5922ba3bBBafa39Dc0677353D2AF17 (EOA/emergency/zendragon)"          |            |          |
+|                       |                                                            |       |   ],                                                                                |            |          |
+|                       |                                                            |       |   "newOwner": [                                                                     |            |          |
+|                       |                                                            |       |     "0x823DF0278e4998cD0D06FB857fBD51e85b18A250 (EOA/dao/nanexcool)"                |            |          |
+|                       |                                                            |       |   ]                                                                                 |            |          |
+|                       |                                                            |       | }                                                                                   |            |          |
+| swapOwner             | 0x4f22C2784Cbd2B24a172566491Ee73fee1A63c2e (multisigs/dao) | 0     | {                                                                                   | N/A        |   N/A    |
+|                       |                                                            |       |   "prevOwner": [                                                                    |            |          |
+|                       |                                                            |       |     "0x823DF0278e4998cD0D06FB857fBD51e85b18A250 (EOA/dao/nanexcool)"                |            |          |
+|                       |                                                            |       |   ],                                                                                |            |          |
+|                       |                                                            |       |   "oldOwner": [                                                                     |            |          |
+|                       |                                                            |       |     "0x512fce9B07Ce64590849115EE6B32fd40eC0f5F3 (EOA/emeritus/solarcurve_signer)"   |            |          |
+|                       |                                                            |       |   ],                                                                                |            |          |
+|                       |                                                            |       |   "newOwner": [                                                                     |            |          |
+|                       |                                                            |       |     "0xAc1aA53108712d7f38093A67d380aD54B562a650 (EOA/dao/davgarai)"                 |            |          |
+|                       |                                                            |       |   ]                                                                                 |            |          |
+|                       |                                                            |       | }                                                                                   |            |          |
+| addOwnerWithThreshold | 0x4f22C2784Cbd2B24a172566491Ee73fee1A63c2e (multisigs/dao) | 0     | {                                                                                   | N/A        |   N/A    |
+|                       |                                                            |       |   "owner": [                                                                        |            |          |
+|                       |                                                            |       |     "0x9F7dfAb2222A473284205cdDF08a677726d786A0 (EOA/dao/StefanDGeorge)"            |            |          |
+|                       |                                                            |       |   ],                                                                                |            |          |
+|                       |                                                            |       |   "_threshold": [                                                                   |            |          |
+|                       |                                                            |       |     "6"                                                                             |            |          |
+|                       |                                                            |       |   ]                                                                                 |            |          |
+|                       |                                                            |       | }                                                                                   |            |          |
+| addOwnerWithThreshold | 0x4f22C2784Cbd2B24a172566491Ee73fee1A63c2e (multisigs/dao) | 0     | {                                                                                   | N/A        |   N/A    |
+|                       |                                                            |       |   "owner": [                                                                        |            |          |
+|                       |                                                            |       |     "0x9BE6ff2A1D5139Eda96339E2644dC1F05d803600 (EOA/dao/bonustrack87)"             |            |          |
+|                       |                                                            |       |   ],                                                                                |            |          |
+|                       |                                                            |       |   "_threshold": [                                                                   |            |          |
+|                       |                                                            |       |     "6"                                                                             |            |          |
+|                       |                                                            |       |   ]                                                                                 |            |          |
+|                       |                                                            |       | }                                                                                   |            |          |
+| addOwnerWithThreshold | 0x4f22C2784Cbd2B24a172566491Ee73fee1A63c2e (multisigs/dao) | 0     | {                                                                                   | N/A        |   N/A    |
+|                       |                                                            |       |   "owner": [                                                                        |            |          |
+|                       |                                                            |       |     "0x285b7EEa81a5B66B62e7276a24c1e0F83F7409c1 (EOA/dao/0xMaki)"                   |            |          |
+|                       |                                                            |       |   ],                                                                                |            |          |
+|                       |                                                            |       |   "_threshold": [                                                                   |            |          |
+|                       |                                                            |       |     "6"                                                                             |            |          |
+|                       |                                                            |       |   ]                                                                                 |            |          |
+|                       |                                                            |       | }                                                                                   |            |          |
++-----------------------+------------------------------------------------------------+-------+-------------------------------------------------------------------------------------+------------+----------+
+```


### PR DESCRIPTION
dao msig on sonic still has default signers and low threshold (2/n)

this payload sets signers on par with dao msig on ethereum and raises threshold to 6/n