### PR TITLE
Surge-Settings-New-Pools-March-14-2025

### DIFF
--- a/MaxiOps/PoolParameterChanges/PoolStableSurgeParams/Arbitrum/awstETH-fWETH-2%T-5%M.json
+++ b/MaxiOps/PoolParameterChanges/PoolStableSurgeParams/Arbitrum/awstETH-fWETH-2%T-5%M.json
@@ -1,0 +1,57 @@
+{
+  "version": "1.0",
+  "chainId": "42161",
+  "createdAt": 1741983337663,
+  "meta": {
+    "name": "Transactions Batch",
+    "description": "",
+    "txBuilderVersion": "1.18.0",
+    "createdFromSafeAddress": "0x9ff471F9f98F42E5151C7855fD1b5aa906b1AF7e",
+    "createdFromOwnerAddress": "",
+    "checksum": "0xf7f3b466f1e36321e67a50506eddd25ed5e656b0f62c0f78f98afda1c80e77c5"
+  },
+  "transactions": [
+    {
+      "to": "0x0Fa0f9990D7969a7aE6f9961d663E4A201Ed6417",
+      "value": "0",
+      "data": null,
+      "contractMethod": {
+        "inputs": [
+          { "internalType": "address", "name": "pool", "type": "address" },
+          {
+            "internalType": "uint256",
+            "name": "newMaxSurgeSurgeFeePercentage",
+            "type": "uint256"
+          }
+        ],
+        "name": "setMaxSurgeFeePercentage",
+        "payable": false
+      },
+      "contractInputsValues": {
+        "pool": "0xB1B8B406EeeBBB636fdBB20E6732c117d828363C",
+        "newMaxSurgeSurgeFeePercentage": "50000000000000000"
+      }
+    },
+    {
+      "to": "0x0Fa0f9990D7969a7aE6f9961d663E4A201Ed6417",
+      "value": "0",
+      "data": null,
+      "contractMethod": {
+        "inputs": [
+          { "internalType": "address", "name": "pool", "type": "address" },
+          {
+            "internalType": "uint256",
+            "name": "newSurgeThresholdPercentage",
+            "type": "uint256"
+          }
+        ],
+        "name": "setSurgeThresholdPercentage",
+        "payable": false
+      },
+      "contractInputsValues": {
+        "pool": "0xB1B8B406EeeBBB636fdBB20E6732c117d828363C",
+        "newSurgeThresholdPercentage": "20000000000000000"
+      }
+    }
+  ]
+}

--- a/MaxiOps/PoolParameterChanges/PoolStableSurgeParams/Base/awstETH-fWETH-2%T-5%M.json
+++ b/MaxiOps/PoolParameterChanges/PoolStableSurgeParams/Base/awstETH-fWETH-2%T-5%M.json
@@ -1,0 +1,57 @@
+{
+  "version": "1.0",
+  "chainId": "8453",
+  "createdAt": 1741983487804,
+  "meta": {
+    "name": "Transactions Batch",
+    "description": "",
+    "txBuilderVersion": "1.18.0",
+    "createdFromSafeAddress": "0x9ff471F9f98F42E5151C7855fD1b5aa906b1AF7e",
+    "createdFromOwnerAddress": "",
+    "checksum": "0xde3d387ae15c4084bcfa3383d9af09fcc1894bb559c391eec07508d5bcb13b48"
+  },
+  "transactions": [
+    {
+      "to": "0xb2007B8B7E0260042517f635CFd8E6dD2Dd7f007",
+      "value": "0",
+      "data": null,
+      "contractMethod": {
+        "inputs": [
+          { "internalType": "address", "name": "pool", "type": "address" },
+          {
+            "internalType": "uint256",
+            "name": "newMaxSurgeSurgeFeePercentage",
+            "type": "uint256"
+          }
+        ],
+        "name": "setMaxSurgeFeePercentage",
+        "payable": false
+      },
+      "contractInputsValues": {
+        "pool": "0x9972c4f21b5Ae6062233031314aDbBddA7513Ed2",
+        "newMaxSurgeSurgeFeePercentage": "50000000000000000"
+      }
+    },
+    {
+      "to": "0xb2007B8B7E0260042517f635CFd8E6dD2Dd7f007",
+      "value": "0",
+      "data": null,
+      "contractMethod": {
+        "inputs": [
+          { "internalType": "address", "name": "pool", "type": "address" },
+          {
+            "internalType": "uint256",
+            "name": "newSurgeThresholdPercentage",
+            "type": "uint256"
+          }
+        ],
+        "name": "setSurgeThresholdPercentage",
+        "payable": false
+      },
+      "contractInputsValues": {
+        "pool": "0x9972c4f21b5Ae6062233031314aDbBddA7513Ed2",
+        "newSurgeThresholdPercentage": "20000000000000000"
+      }
+    }
+  ]
+}

--- a/MaxiOps/PoolParameterChanges/PoolStableSurgeParams/Gnosis/aUSDC-aEURe-Surge-0.5%T-1%M.json
+++ b/MaxiOps/PoolParameterChanges/PoolStableSurgeParams/Gnosis/aUSDC-aEURe-Surge-0.5%T-1%M.json
@@ -1,0 +1,57 @@
+{
+  "version": "1.0",
+  "chainId": "100",
+  "createdAt": 1741983710361,
+  "meta": {
+    "name": "Transactions Batch",
+    "description": "",
+    "txBuilderVersion": "1.18.0",
+    "createdFromSafeAddress": "0x9ff471F9f98F42E5151C7855fD1b5aa906b1AF7e",
+    "createdFromOwnerAddress": "",
+    "checksum": "0xf3b2da05b1115faf48f2671780bc46a19e3fce627724731f34dd794fd658de92"
+  },
+  "transactions": [
+    {
+      "to": "0xe4f1878eC9710846E2B529C1b5037F8bA94583b1",
+      "value": "0",
+      "data": null,
+      "contractMethod": {
+        "inputs": [
+          { "internalType": "address", "name": "pool", "type": "address" },
+          {
+            "internalType": "uint256",
+            "name": "newMaxSurgeSurgeFeePercentage",
+            "type": "uint256"
+          }
+        ],
+        "name": "setMaxSurgeFeePercentage",
+        "payable": false
+      },
+      "contractInputsValues": {
+        "pool": "0xdBc150E4F420eD2E08A8068920E84733baf2f5D4",
+        "newMaxSurgeSurgeFeePercentage": "10000000000000000"
+      }
+    },
+    {
+      "to": "0xe4f1878eC9710846E2B529C1b5037F8bA94583b1",
+      "value": "0",
+      "data": null,
+      "contractMethod": {
+        "inputs": [
+          { "internalType": "address", "name": "pool", "type": "address" },
+          {
+            "internalType": "uint256",
+            "name": "newSurgeThresholdPercentage",
+            "type": "uint256"
+          }
+        ],
+        "name": "setSurgeThresholdPercentage",
+        "payable": false
+      },
+      "contractInputsValues": {
+        "pool": "0xdBc150E4F420eD2E08A8068920E84733baf2f5D4",
+        "newSurgeThresholdPercentage": "5000000000000000"
+      }
+    }
+  ]
+}

--- a/MaxiOps/PoolParameterChanges/PoolStableSurgeParams/Mainnet/awstETH-fWETH-2%T-5%M.json
+++ b/MaxiOps/PoolParameterChanges/PoolStableSurgeParams/Mainnet/awstETH-fWETH-2%T-5%M.json
@@ -1,0 +1,57 @@
+{
+  "version": "1.0",
+  "chainId": "1",
+  "createdAt": 1741983592687,
+  "meta": {
+    "name": "Transactions Batch",
+    "description": "",
+    "txBuilderVersion": "1.18.0",
+    "createdFromSafeAddress": "0x9ff471F9f98F42E5151C7855fD1b5aa906b1AF7e",
+    "createdFromOwnerAddress": "",
+    "checksum": "0xa26c27308d0d9b7c43fefe6422afa616dddb2de4a5a36f92047369cc77983813"
+  },
+  "transactions": [
+    {
+      "to": "0xb18fA0cb5DE8cecB8899AAE6e38b1B7ed77885dA",
+      "value": "0",
+      "data": null,
+      "contractMethod": {
+        "inputs": [
+          { "name": "pool", "type": "address", "internalType": "address" },
+          {
+            "name": "newMaxSurgeSurgeFeePercentage",
+            "type": "uint256",
+            "internalType": "uint256"
+          }
+        ],
+        "name": "setMaxSurgeFeePercentage",
+        "payable": false
+      },
+      "contractInputsValues": {
+        "pool": "0x91a815b884E27bf6a688Ba9eED97720c5Cf3550A",
+        "newMaxSurgeSurgeFeePercentage": "50000000000000000"
+      }
+    },
+    {
+      "to": "0xb18fA0cb5DE8cecB8899AAE6e38b1B7ed77885dA",
+      "value": "0",
+      "data": null,
+      "contractMethod": {
+        "inputs": [
+          { "name": "pool", "type": "address", "internalType": "address" },
+          {
+            "name": "newSurgeThresholdPercentage",
+            "type": "uint256",
+            "internalType": "uint256"
+          }
+        ],
+        "name": "setSurgeThresholdPercentage",
+        "payable": false
+      },
+      "contractInputsValues": {
+        "pool": "0x91a815b884E27bf6a688Ba9eED97720c5Cf3550A",
+        "newSurgeThresholdPercentage": "20000000000000000"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
For all fWETH-Aave wstETH pools for Lido threshold of 2% max fee of 5%. Mainnet, Arbitrum, and Base

For Aave boosted USDC.e - EURe threshold of 0.5% and max fee of 1% as agreed by Karpatkey.