### PR TITLE
Arbitrum USDC Grant - Week 2 incentive Plan

### DIFF
--- a/MaxiOps/injectorScheduling/arbitrum/Arbitrum-USDC-Grant-Schedule-Week2.json
+++ b/MaxiOps/injectorScheduling/arbitrum/Arbitrum-USDC-Grant-Schedule-Week2.json
@@ -1,0 +1,86 @@
+{
+  "version": "1.0",
+  "chainId": "42161",
+  "createdAt": 1742476070,
+  "meta": {
+    "name": "Rewards Injector Schedule - ADD",
+    "description": "Configure rewards injector schedule to add recipients",
+    "createdFromSafeAddress": "0x9ff471F9f98F42E5151C7855fD1b5aa906b1AF7e"
+  },
+  "transactions": [
+    {
+      "to": "0x08F02E2945C175272Acbb238ACCB6eda56129DE8",
+      "value": "0",
+      "data": null,
+      "contractMethod": {
+        "inputs": [
+          {
+            "name": "recipients",
+            "type": "address[]",
+            "internalType": "address[]"
+          },
+          {
+            "name": "amountPerPeriod",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "maxPeriods",
+            "type": "uint8",
+            "internalType": "uint8"
+          },
+          {
+            "name": "doNotStartBeforeTimestamp",
+            "type": "uint56",
+            "internalType": "uint56"
+          }
+        ],
+        "name": "addRecipients",
+        "payable": false
+      },
+      "contractInputsValues": {
+        "recipients": "[0xB4259ce2724Fe85182fEE38AC78b794291FaD997, 0xf3E7b852390478FAa6D44319bDE4782bf35BF2bD]",
+        "amountPerPeriod": "1850000000",
+        "maxPeriods": "1",
+        "doNotStartBeforeTimestamp": "1742486400"
+      }
+    },
+    {
+      "to": "0x08F02E2945C175272Acbb238ACCB6eda56129DE8",
+      "value": "0",
+      "data": null,
+      "contractMethod": {
+        "inputs": [
+          {
+            "name": "recipients",
+            "type": "address[]",
+            "internalType": "address[]"
+          },
+          {
+            "name": "amountPerPeriod",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "maxPeriods",
+            "type": "uint8",
+            "internalType": "uint8"
+          },
+          {
+            "name": "doNotStartBeforeTimestamp",
+            "type": "uint56",
+            "internalType": "uint56"
+          }
+        ],
+        "name": "addRecipients",
+        "payable": false
+      },
+      "contractInputsValues": {
+        "recipients": "[0x5802e74ac511eaf7Adf0c7092136Ba60fDE1c3E4, 0x946fb8fcfa21dbdd2152dac1d39bd30c10679d76]",
+        "amountPerPeriod": "2500000000",
+        "maxPeriods": "1",
+        "doNotStartBeforeTimestamp": "1742486400"
+      }
+    }
+  ]
+}

--- a/MaxiOps/injectorScheduling/arbitrum/Arbitrum-USDC-Grant-Schedule-Week2.report.txt
+++ b/MaxiOps/injectorScheduling/arbitrum/Arbitrum-USDC-Grant-Schedule-Week2.report.txt
@@ -1,0 +1,42 @@
+FILENAME: `MaxiOps/injectorScheduling/arbitrum/Arbitrum-USDC-Grant-Schedule-Week2.json`
+MULTISIG: `multisigs/maxi_omni (arbitrum:0x9ff471F9f98F42E5151C7855fD1b5aa906b1AF7e)`
+COMMIT: `336c468791e370cc172f0f7687d82c6ee2bc1931`
+CHAIN(S): `arbitrum`
+TENDERLY: [`🟩 SUCCESS`](https://www.tdly.co/shared/simulation/7af982fa-3ed6-44bb-aaeb-90713fb22148)
+
+```
++---------------+----------------------------------------------------------------------------------------------+-------+---------------------------------------------------------------------------------------------+------------+----------+
+| fx_name       | to                                                                                           | value | inputs                                                                                      | bip_number | tx_index |
++---------------+----------------------------------------------------------------------------------------------+-------+---------------------------------------------------------------------------------------------+------------+----------+
+| addRecipients | 0x08F02E2945C175272Acbb238ACCB6eda56129DE8 (maxiKeepers/injectorV2/USDC-ARB-Grant-omnichain) | 0     | {                                                                                           | N/A        |   N/A    |
+|               |                                                                                              |       |   "recipients": [                                                                           |            |          |
+|               |                                                                                              |       |     "0xB4259ce2724Fe85182fEE38AC78b794291FaD997 (gauges/Surge eBTC-Aave WBTC-gauge-b425)",  |            |          |
+|               |                                                                                              |       |     "0xf3E7b852390478FAa6D44319bDE4782bf35BF2bD (gauges/Surge orbETH-Aave wETH-gauge-f3e7)" |            |          |
+|               |                                                                                              |       |   ],                                                                                        |            |          |
+|               |                                                                                              |       |   "amountPerPeriod": [                                                                      |            |          |
+|               |                                                                                              |       |     "raw:1850000000, 18 decimals:1.85E-9, 6 decimals: 1850"                                 |            |          |
+|               |                                                                                              |       |   ],                                                                                        |            |          |
+|               |                                                                                              |       |   "maxPeriods": [                                                                           |            |          |
+|               |                                                                                              |       |     "1"                                                                                     |            |          |
+|               |                                                                                              |       |   ],                                                                                        |            |          |
+|               |                                                                                              |       |   "doNotStartBeforeTimestamp": [                                                            |            |          |
+|               |                                                                                              |       |     "1742486400"                                                                            |            |          |
+|               |                                                                                              |       |   ]                                                                                         |            |          |
+|               |                                                                                              |       | }                                                                                           |            |          |
+| addRecipients | 0x08F02E2945C175272Acbb238ACCB6eda56129DE8 (maxiKeepers/injectorV2/USDC-ARB-Grant-omnichain) | 0     | {                                                                                           | N/A        |   N/A    |
+|               |                                                                                              |       |   "recipients": [                                                                           |            |          |
+|               |                                                                                              |       |     "0x5802e74ac511eaf7Adf0c7092136Ba60fDE1c3E4 (N/A)",                                     |            |          |
+|               |                                                                                              |       |     "0x946fb8fcfa21dbdd2152dac1d39bd30c10679d76 (N/A)"                                      |            |          |
+|               |                                                                                              |       |   ],                                                                                        |            |          |
+|               |                                                                                              |       |   "amountPerPeriod": [                                                                      |            |          |
+|               |                                                                                              |       |     "raw:2500000000, 18 decimals:2.5E-9, 6 decimals: 2500"                                  |            |          |
+|               |                                                                                              |       |   ],                                                                                        |            |          |
+|               |                                                                                              |       |   "maxPeriods": [                                                                           |            |          |
+|               |                                                                                              |       |     "1"                                                                                     |            |          |
+|               |                                                                                              |       |   ],                                                                                        |            |          |
+|               |                                                                                              |       |   "doNotStartBeforeTimestamp": [                                                            |            |          |
+|               |                                                                                              |       |     "1742486400"                                                                            |            |          |
+|               |                                                                                              |       |   ]                                                                                         |            |          |
+|               |                                                                                              |       | }                                                                                           |            |          |
++---------------+----------------------------------------------------------------------------------------------+-------+---------------------------------------------------------------------------------------------+------------+----------+
+```


### PR DESCRIPTION
- Execute week 2 incentives as per [notion](https://www.notion.so/18de395e22818014b713e5e5f35095a4?v=18de395e228180f7ae12000cf007f5da)
- align incentives on existing pools and new ECLPs at 5PM CET 20.03.2025

eBTC v3 pools will reduce to 1850 USDC a week
New ECLPs will get 2500 USDC a week

We decided with @Zen-Maxi to only configure for 1 week and reconfigure a new longer schedule thereafter.