### PR TITLE
aura voting: add eth-account

### DIFF
--- a/tools/python/aura_snapshot_voting/requirements.txt
+++ b/tools/python/aura_snapshot_voting/requirements.txt
@@ -4,4 +4,4 @@ git+https://github.com/BalancerMaxis/bal_addresses.git@0.9.15#egg=bal_addresses
 dune-client
 dataclasses-json
 tabulate
-eth-account
+eth-account==0.10.0

--- a/tools/python/aura_snapshot_voting/requirements.txt
+++ b/tools/python/aura_snapshot_voting/requirements.txt
@@ -4,3 +4,4 @@ git+https://github.com/BalancerMaxis/bal_addresses.git@0.9.15#egg=bal_addresses
 dune-client
 dataclasses-json
 tabulate
+eth-account

--- a/tools/python/aura_snapshot_voting/vote.py
+++ b/tools/python/aura_snapshot_voting/vote.py
@@ -63,6 +63,7 @@ def post_safe_tx(safe_address, to_address, value, data, operation):
         to_address, value, data, operation, safe_nonce=nonce
     )
 
+    
     private_key = Account.from_mnemonic(PRIVATE_WORDS).key
     safe_tx.sign(private_key.hex()[2:])
 

--- a/tools/python/aura_snapshot_voting/vote.py
+++ b/tools/python/aura_snapshot_voting/vote.py
@@ -63,7 +63,7 @@ def post_safe_tx(safe_address, to_address, value, data, operation):
         to_address, value, data, operation, safe_nonce=nonce
     )
 
-    private_key = Account.from_mnemonic(PRIVATE_WORDS).privateKey
+    private_key = Account.from_mnemonic(PRIVATE_WORDS).key
     safe_tx.sign(private_key.hex()[2:])
 
     safe_service.post_transaction(safe_tx)

--- a/tools/python/aura_snapshot_voting/vote.py
+++ b/tools/python/aura_snapshot_voting/vote.py
@@ -63,7 +63,6 @@ def post_safe_tx(safe_address, to_address, value, data, operation):
         to_address, value, data, operation, safe_nonce=nonce
     )
 
-    
     private_key = Account.from_mnemonic(PRIVATE_WORDS).key
     safe_tx.sign(private_key.hex()[2:])
 


### PR DESCRIPTION
the dep changes in #1860 that were needed to get the reporting automation to work broke the posting part. pinning `eth-account` seems to get both working now

also needs to use new [`key`](https://eth-account.readthedocs.io/en/stable/eth_account.signers.html#eth_account.signers.local.LocalAccount.key) attribute