### PR TITLE
ci: remove redundant deps

### DIFF
--- a/tools/python/requirements.txt
+++ b/tools/python/requirements.txt
@@ -1,12 +1,4 @@
-eth-abi==5.0.1
-datetime
-dotmap
-pandas
 tabulate
-requests
-web3
 git+https://github.com/BalancerMaxis/bal_addresses
 dune-client
-pytest
 dataclasses-json
-python-dotenv


### PR DESCRIPTION
here is the dep tree that comes with bal addresses:
```
aiohappyeyeballs==2.6.1; python_version >= '3.9'
aiohttp==3.11.0b0; python_version >= '3.9'
aiosignal==1.3.1; python_version >= '3.7'
annotated-types==0.7.0; python_version >= '3.8'
anyio==4.9.0; python_version >= '3.9'
asttokens==2.4.1
async-timeout==4.0.3; python_version >= '3.7'
attrs==23.2.0; python_version >= '3.7'
backoff==2.2.1; python_version >= '3.7' and python_version < '4.0'
bal-tools @ git+https://github.com/BalancerMaxis/bal_tools.git@1ceff1066ff4aa22afc9fe3d89fc4e02032e2d06
bitarray==2.9.2
black==24.2.0; python_version >= '3.8'
cbor2==5.6.2; python_version >= '3.8'
cchecksum==0.0.7; python_version >= '3.8' and python_version < '4'
certifi==2024.2.2; python_version >= '3.6'
charset-normalizer==3.3.2; python_full_version >= '3.7.0'
click==8.1.7; python_version >= '3.7'
cytoolz==0.12.3; python_version >= '3.7'
dataclassy==0.11.1; python_version >= '3.6'
dotmap==1.3.30
eip712==0.2.4; python_version >= '3.8' and python_version < '4'
eth-abi==5.0.1; python_version >= '3.8' and python_version < '4'
eth-account==0.10.0; python_version >= '3.7' and python_version < '4'
eth-brownie @ git+https://github.com/BalancerMaxis/brownie.git@07ff5e67edabcbbb328dae2a443a7785d26db302
eth-event==1.2.5; python_version >= '3.6' and python_version < '4'
eth-hash[pycryptodome]==0.6.0; python_version >= '3.8' and python_version < '4'
eth-keyfile==0.7.0; python_version >= '3.8' and python_version < '4'
eth-keys==0.5.0; python_version >= '3.8' and python_version < '4'
eth-rlp==1.0.1; python_version >= '3.8' and python_version < '4'
eth-typing==3.5.2; python_full_version >= '3.7.2' and python_version < '4'
eth-utils==2.3.1; python_version >= '3.7' and python_version < '4'
exceptiongroup==1.2.2; python_version >= '3.7'
execnet==2.0.2; python_version >= '3.7'
frozenlist==1.4.1; python_version >= '3.8'
gql[requests]==3.5.2
graphql-core==3.2.4; python_version >= '3.6' and python_version < '4'
hexbytes==0.3.1; python_version >= '3.7' and python_version < '4'
hypothesis==6.27.3; python_version >= '3.6'
idna==3.6; python_version >= '3.5'
importlib-metadata==7.0.1; python_version >= '3.8'
iniconfig==2.0.0; python_version >= '3.7'
json-fix==1.0.0; python_version >= '3.6'
jsonschema==4.21.1; python_version >= '3.8'
jsonschema-specifications==2023.12.1; python_version >= '3.8'
lazy-object-proxy==1.10.0; python_version >= '3.8'
lru-dict==1.2.0
lxml==5.3.1; python_version >= '3.6'
multidict==6.0.5; python_version >= '3.7'
munch==4.0.0; python_version >= '3.6'
mypy-extensions==1.0.0; python_version >= '3.5'
numpy==1.26.4; python_version >= '3.9'
packaging==23.2; python_version >= '3.7'
pandas==2.2.3; python_version >= '3.9'
parsimonious==0.9.0
pathlib==1.0.1
pathspec==0.12.1; python_version >= '3.8'
platformdirs==4.2.0; python_version >= '3.8'
pluggy==1.4.0; python_version >= '3.8'
prompt-toolkit==3.0.43; python_full_version >= '3.7.0'
propcache==0.3.0; python_version >= '3.9'
protobuf==4.25.3; python_version >= '3.8'
psutil==5.9.8; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'
py==1.11.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'
py-solc-ast==1.2.10; python_version >= '3.6' and python_version < '4'
py-solc-x==1.1.1; python_version >= '3.6' and python_version < '4'
pycryptodome==3.20.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'
pydantic==2.9.2; python_version >= '3.8'
pydantic-core==2.23.4; python_version >= '3.8'
pygments==2.17.2; python_version >= '3.7'
pygments-lexer-solidity==0.7.0
pytest==6.2.5; python_version >= '3.6'
pytest-forked==1.6.0; python_version >= '3.7'
pytest-xdist==1.34.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'
python-dateutil==2.9.0.post0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'
python-dotenv==0.16.0
pytz==2025.2
pyunormalize==15.1.0; python_version >= '3.6'
pyyaml==6.0.1; python_version >= '3.6'
referencing==0.33.0; python_version >= '3.8'
regex==2023.12.25; python_version >= '3.7'
requests==2.31.0; python_version >= '3.7'
requests-toolbelt==1.0.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
rlp==4.0.0; python_version >= '3.8' and python_version < '4'
rpds-py==0.18.0; python_version >= '3.8'
semantic-version==2.10.0; python_version >= '2.7'
six==1.16.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'
sniffio==1.3.1; python_version >= '3.7'
sortedcontainers==2.4.0
toml==0.10.2; python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2'
tomli==2.2.1; python_version >= '3.8'
toolz==0.12.1; python_version >= '3.7'
tqdm==4.66.3; python_version >= '3.7'
typing-extensions==4.9.0; python_version >= '3.8'
tzdata==2025.2; python_version >= '2'
urllib3==2.2.1; python_version >= '3.8'
vvm==0.2.1; python_version >= '3.6' and python_version < '4'
vyper==0.4.0; python_version >= '3.10' and python_version < '4'
wcwidth==0.2.13
web3==6.15.1; python_full_version >= '3.7.2'
websockets==12.0; python_version >= '3.8'
wheel==0.42.0; python_version >= '3.7'
wrapt==1.16.0; python_version >= '3.6'
yarl==1.18.3; python_version >= '3.9'
zipp==3.17.0; python_version >= '3.8'
```