### PR TITLE
Adjust GHO Swap Fees on v3 Pools on Base

### DIFF
--- a/MaxiOps/PoolParameterChanges/PoolSwapFeeChanges/Base/GHO-v3-pool-changes-2025_04_03.json
+++ b/MaxiOps/PoolParameterChanges/PoolSwapFeeChanges/Base/GHO-v3-pool-changes-2025_04_03.json
@@ -1,0 +1,87 @@
+{
+  "version": "1.0",
+  "chainId": "8453",
+  "createdAt": 1743691699479,
+  "meta": {
+    "name": "Transactions Batch",
+    "description": "Set swap fee to 0.02% for Balancer Aave USDC-Aave GHO and other pools",
+    "createdFromSafeAddress": "0x9ff471F9f98F42E5151C7855fD1b5aa906b1AF7e"
+  },
+  "transactions": [
+    {
+      "to": "0xbA1333333333a1BA1108E8412f11850A5C319bA9",
+      "value": "0",
+      "data": null,
+      "contractMethod": {
+        "inputs": [
+          {
+            "name": "pool",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "swapFeePercentage",
+            "type": "uint256",
+            "internalType": "uint256"
+          }
+        ],
+        "name": "setStaticSwapFeePercentage",
+        "payable": false
+      },
+      "contractInputsValues": {
+        "pool": "0x7ab124ec4029316c2a42f713828ddf2a192b36db",
+        "swapFeePercentage": "200000000000000"
+      }
+    },
+    {
+      "to": "0xbA1333333333a1BA1108E8412f11850A5C319bA9",
+      "value": "0",
+      "data": null,
+      "contractMethod": {
+        "inputs": [
+          {
+            "name": "pool",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "swapFeePercentage",
+            "type": "uint256",
+            "internalType": "uint256"
+          }
+        ],
+        "name": "setStaticSwapFeePercentage",
+        "payable": false
+      },
+      "contractInputsValues": {
+        "pool": "0x9ab907fb3e098103ca048ad26e501bf7b3dfa3eb",
+        "swapFeePercentage": "100000000000000"
+      }
+    },
+    {
+      "to": "0xbA1333333333a1BA1108E8412f11850A5C319bA9",
+      "value": "0",
+      "data": null,
+      "contractMethod": {
+        "inputs": [
+          {
+            "name": "pool",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "swapFeePercentage",
+            "type": "uint256",
+            "internalType": "uint256"
+          }
+        ],
+        "name": "setStaticSwapFeePercentage",
+        "payable": false
+      },
+      "contractInputsValues": {
+        "pool": "0x5b14ce8de84448e9a6f6af652af318472aa4fcaf",
+        "swapFeePercentage": "100000000000000"
+      }
+    }
+  ]
+}

--- a/MaxiOps/PoolParameterChanges/PoolSwapFeeChanges/Base/GHO-v3-pool-changes-2025_04_03.json
+++ b/MaxiOps/PoolParameterChanges/PoolSwapFeeChanges/Base/GHO-v3-pool-changes-2025_04_03.json
@@ -80,7 +80,7 @@
       },
       "contractInputsValues": {
         "pool": "0x5b14ce8de84448e9a6f6af652af318472aa4fcaf",
-        "swapFeePercentage": "100000000000000"
+        "swapFeePercentage": "200000000000000"
       }
     }
   ]

--- a/MaxiOps/PoolParameterChanges/PoolSwapFeeChanges/Base/GHO-v3-pool-changes-2025_04_03.report.txt
+++ b/MaxiOps/PoolParameterChanges/PoolSwapFeeChanges/Base/GHO-v3-pool-changes-2025_04_03.report.txt
@@ -1,0 +1,36 @@
+FILENAME: `MaxiOps/PoolParameterChanges/PoolSwapFeeChanges/Base/GHO-v3-pool-changes-2025_04_03.json`
+MULTISIG: `multisigs/maxi_omni (base:0x9ff471F9f98F42E5151C7855fD1b5aa906b1AF7e)`
+COMMIT: `dce59cbe78ed2d47b2de9318c7453353eb052fac`
+CHAIN(S): `base`
+TENDERLY: [`🟩 SUCCESS`](https://www.tdly.co/shared/simulation/47d566d8-a083-474a-89dd-680d7d2ebd50)
+
+```
++----------------------------+----------------------------------------------------------------------+-------+-----------------------------------------------------------------------------------+------------+----------+
+| fx_name                    | to                                                                   | value | inputs                                                                            | bip_number | tx_index |
++----------------------------+----------------------------------------------------------------------+-------+-----------------------------------------------------------------------------------+------------+----------+
+| setStaticSwapFeePercentage | 0xbA1333333333a1BA1108E8412f11850A5C319bA9 (20241204-v3-vault/Vault) | 0     | {                                                                                 | N/A        |   N/A    |
+|                            |                                                                      |       |   "pool": [                                                                       |            |          |
+|                            |                                                                      |       |     "0x7ab124ec4029316c2a42f713828ddf2a192b36db (pools/Aave USDC-Aave GHO-7ab1)"  |            |          |
+|                            |                                                                      |       |   ],                                                                              |            |          |
+|                            |                                                                      |       |   "swapFeePercentage": [                                                          |            |          |
+|                            |                                                                      |       |     "200000000000000"                                                             |            |          |
+|                            |                                                                      |       |   ]                                                                               |            |          |
+|                            |                                                                      |       | }                                                                                 |            |          |
+| setStaticSwapFeePercentage | 0xbA1333333333a1BA1108E8412f11850A5C319bA9 (20241204-v3-vault/Vault) | 0     | {                                                                                 | N/A        |   N/A    |
+|                            |                                                                      |       |   "pool": [                                                                       |            |          |
+|                            |                                                                      |       |     "0x9ab907fb3e098103ca048ad26e501bf7b3dfa3eb (pools/Surge Aave EURC-GHO-9ab9)" |            |          |
+|                            |                                                                      |       |   ],                                                                              |            |          |
+|                            |                                                                      |       |   "swapFeePercentage": [                                                          |            |          |
+|                            |                                                                      |       |     "100000000000000"                                                             |            |          |
+|                            |                                                                      |       |   ]                                                                               |            |          |
+|                            |                                                                      |       | }                                                                                 |            |          |
+| setStaticSwapFeePercentage | 0xbA1333333333a1BA1108E8412f11850A5C319bA9 (20241204-v3-vault/Vault) | 0     | {                                                                                 | N/A        |   N/A    |
+|                            |                                                                      |       |   "pool": [                                                                       |            |          |
+|                            |                                                                      |       |     "0x5b14ce8de84448e9a6f6af652af318472aa4fcaf (pools/Aave GHO-USR-5b14)"        |            |          |
+|                            |                                                                      |       |   ],                                                                              |            |          |
+|                            |                                                                      |       |   "swapFeePercentage": [                                                          |            |          |
+|                            |                                                                      |       |     "100000000000000"                                                             |            |          |
+|                            |                                                                      |       |   ]                                                                               |            |          |
+|                            |                                                                      |       | }                                                                                 |            |          |
++----------------------------+----------------------------------------------------------------------+-------+-----------------------------------------------------------------------------------+------------+----------+
+```

--- a/MaxiOps/PoolParameterChanges/PoolSwapFeeChanges/Base/GHO-v3-pool-changes-2025_04_03.report.txt
+++ b/MaxiOps/PoolParameterChanges/PoolSwapFeeChanges/Base/GHO-v3-pool-changes-2025_04_03.report.txt
@@ -1,8 +1,8 @@
 FILENAME: `MaxiOps/PoolParameterChanges/PoolSwapFeeChanges/Base/GHO-v3-pool-changes-2025_04_03.json`
 MULTISIG: `multisigs/maxi_omni (base:0x9ff471F9f98F42E5151C7855fD1b5aa906b1AF7e)`
-COMMIT: `dce59cbe78ed2d47b2de9318c7453353eb052fac`
+COMMIT: `f64dee387efbaef818817b64fc51a0619433aa7e`
 CHAIN(S): `base`
-TENDERLY: [`🟩 SUCCESS`](https://www.tdly.co/shared/simulation/47d566d8-a083-474a-89dd-680d7d2ebd50)
+TENDERLY: [`🟩 SUCCESS`](https://www.tdly.co/shared/simulation/9aa12d33-1853-4fd5-9db2-9ba090bdd5f1)
 
 ```
 +----------------------------+----------------------------------------------------------------------+-------+-----------------------------------------------------------------------------------+------------+----------+
@@ -29,7 +29,7 @@ TENDERLY: [`🟩 SUCCESS`](https://www.tdly.co/shared/simulation/47d566d8-a083-4
 |                            |                                                                      |       |     "0x5b14ce8de84448e9a6f6af652af318472aa4fcaf (pools/Aave GHO-USR-5b14)"        |            |          |
 |                            |                                                                      |       |   ],                                                                              |            |          |
 |                            |                                                                      |       |   "swapFeePercentage": [                                                          |            |          |
-|                            |                                                                      |       |     "100000000000000"                                                             |            |          |
+|                            |                                                                      |       |     "200000000000000"                                                             |            |          |
 |                            |                                                                      |       |   ]                                                                               |            |          |
 |                            |                                                                      |       | }                                                                                 |            |          |
 +----------------------------+----------------------------------------------------------------------+-------+-----------------------------------------------------------------------------------+------------+----------+


### PR DESCRIPTION
As per MG request:
- Adjust GHO-USDC to 0.02%
- Adjust GHO-EURC to 0.01%
- Adjust GHO-USR stablesurge to 0.02%
![image](https://github.com/user-attachments/assets/54158428-b75a-4948-8a80-ba30f889036b)
