### PR TITLE
Set Rate Cache to 1 for additional Gnosis pools

### DIFF
--- a/MaxiOps/PoolParameterChanges/PoolRateParameterChanges/Gnosis/GBPeSDAI-stEUREURe-setRateCache-to-1.json
+++ b/MaxiOps/PoolParameterChanges/PoolRateParameterChanges/Gnosis/GBPeSDAI-stEUREURe-setRateCache-to-1.json
@@ -1,0 +1,90 @@
+{
+  "version": "1.0",
+  "chainId": "100",
+  "createdAt": 1744100250303,
+  "meta": {
+    "name": "Transactions Batch",
+    "description": "",
+    "txBuilderVersion": "1.18.0",
+    "createdFromSafeAddress": "0x9ff471F9f98F42E5151C7855fD1b5aa906b1AF7e",
+    "createdFromOwnerAddress": "",
+    "checksum": "0x5cddffeec116901ca71d49c64444aea3fb340b776248997356485fd072ef371a"
+  },
+  "transactions": [
+    {
+      "to": "0x9D93F38b75B376AcDFe607cD1ECF4495E047dEfF",
+      "value": "0",
+      "data": null,
+      "contractMethod": {
+        "inputs": [
+          {
+            "internalType": "contract IERC20",
+            "name": "token",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "duration",
+            "type": "uint256"
+          }
+        ],
+        "name": "setTokenRateCacheDuration",
+        "payable": false
+      },
+      "contractInputsValues": {
+        "token": "0x5Cb9073902F2035222B9749F8fB0c9BFe5527108",
+        "duration": "1"
+      }
+    },
+    {
+      "to": "0x9D93F38b75B376AcDFe607cD1ECF4495E047dEfF",
+      "value": "0",
+      "data": null,
+      "contractMethod": {
+        "inputs": [
+          {
+            "internalType": "contract IERC20",
+            "name": "token",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "duration",
+            "type": "uint256"
+          }
+        ],
+        "name": "setTokenRateCacheDuration",
+        "payable": false
+      },
+      "contractInputsValues": {
+        "token": "0xaf204776c7245bF4147c2612BF6e5972Ee483701",
+        "duration": "1"
+      }
+    },
+    {
+      "to": "0x06135A9Ae830476d3a941baE9010B63732a055F4",
+      "value": "0",
+      "data": null,
+      "contractMethod": {
+        "inputs": [
+          {
+            "internalType": "contract IERC20",
+            "name": "token",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "duration",
+            "type": "uint256"
+          }
+        ],
+        "name": "setTokenRateCacheDuration",
+        "payable": false
+      },
+      "contractInputsValues": {
+        "token": "0x004626A008B1aCdC4c74ab51644093b155e59A23",
+        "duration": "1"
+      }
+    }
+  ]
+}

--- a/MaxiOps/PoolParameterChanges/PoolRateParameterChanges/Gnosis/GBPeSDAI-stEUREURe-setRateCache-to-1.report.txt
+++ b/MaxiOps/PoolParameterChanges/PoolRateParameterChanges/Gnosis/GBPeSDAI-stEUREURe-setRateCache-to-1.report.txt
@@ -1,0 +1,36 @@
+FILENAME: `MaxiOps/PoolParameterChanges/PoolRateParameterChanges/Gnosis/GBPeSDAI-stEUREURe-setRateCache-to-1.json`
+MULTISIG: `multisigs/maxi_omni (gnosis:0x9ff471F9f98F42E5151C7855fD1b5aa906b1AF7e)`
+COMMIT: `035cced5593e6385896e479d865035db801a508d`
+CHAIN(S): `gnosis`
+TENDERLY: [`🟩 SUCCESS`](https://www.tdly.co/shared/simulation/b428e49c-77d7-444a-ac19-3d33eae5e56e)
+
+```
++---------------------------+--------------------------------------------------------------------+-------+----------------------------------------------------------------+------------+----------+
+| fx_name                   | to                                                                 | value | inputs                                                         | bip_number | tx_index |
++---------------------------+--------------------------------------------------------------------+-------+----------------------------------------------------------------+------------+----------+
+| setTokenRateCacheDuration | 0x9D93F38b75B376AcDFe607cD1ECF4495E047dEfF (pools/GBPe/sDAI-9d93)  | 0     | {                                                              | N/A        |   N/A    |
+|                           |                                                                    |       |   "token": [                                                   |            |          |
+|                           |                                                                    |       |     "0x5Cb9073902F2035222B9749F8fB0c9BFe5527108 (N/A)"         |            |          |
+|                           |                                                                    |       |   ],                                                           |            |          |
+|                           |                                                                    |       |   "duration": [                                                |            |          |
+|                           |                                                                    |       |     "1"                                                        |            |          |
+|                           |                                                                    |       |   ]                                                            |            |          |
+|                           |                                                                    |       | }                                                              |            |          |
+| setTokenRateCacheDuration | 0x9D93F38b75B376AcDFe607cD1ECF4495E047dEfF (pools/GBPe/sDAI-9d93)  | 0     | {                                                              | N/A        |   N/A    |
+|                           |                                                                    |       |   "token": [                                                   |            |          |
+|                           |                                                                    |       |     "0xaf204776c7245bF4147c2612BF6e5972Ee483701 (tokens/sDAI)" |            |          |
+|                           |                                                                    |       |   ],                                                           |            |          |
+|                           |                                                                    |       |   "duration": [                                                |            |          |
+|                           |                                                                    |       |     "1"                                                        |            |          |
+|                           |                                                                    |       |   ]                                                            |            |          |
+|                           |                                                                    |       | }                                                              |            |          |
+| setTokenRateCacheDuration | 0x06135A9Ae830476d3a941baE9010B63732a055F4 (pools/stEUR/EURe-0613) | 0     | {                                                              | N/A        |   N/A    |
+|                           |                                                                    |       |   "token": [                                                   |            |          |
+|                           |                                                                    |       |     "0x004626A008B1aCdC4c74ab51644093b155e59A23 (N/A)"         |            |          |
+|                           |                                                                    |       |   ],                                                           |            |          |
+|                           |                                                                    |       |   "duration": [                                                |            |          |
+|                           |                                                                    |       |     "1"                                                        |            |          |
+|                           |                                                                    |       |   ]                                                            |            |          |
+|                           |                                                                    |       | }                                                              |            |          |
++---------------------------+--------------------------------------------------------------------+-------+----------------------------------------------------------------+------------+----------+
+```


### PR DESCRIPTION
GBPe-sDAI: 0x9d93f38b75b376acdfe607cd1ecf4495e047deff
stEUR-EURe: 0x06135a9ae830476d3a941bae9010b63732a055f4

Each token that has a rate provider is set to 1, note that for stEUR-EURe only stEUR has a rate provider configured, so we only set that one

![image](https://github.com/user-attachments/assets/c347eef3-da23-41a8-993c-81c121ca2259)

The first pool in the request has been set already