### PR TITLE
GHO-USDC-A-2000-Surge-Params-5%

### DIFF
--- a/MaxiOps/PoolParameterChanges/PoolAmpChanges/Base/GHO-USDC-A-2000-Surge-Params-5%.json
+++ b/MaxiOps/PoolParameterChanges/PoolAmpChanges/Base/GHO-USDC-A-2000-Surge-Params-5%.json
@@ -1,0 +1,75 @@
+{
+  "version": "1.0",
+  "chainId": "8453",
+  "createdAt": 1744662163894,
+  "meta": {
+    "name": "Transactions Batch",
+    "description": "",
+    "txBuilderVersion": "1.18.0",
+    "createdFromSafeAddress": "0x9ff471F9f98F42E5151C7855fD1b5aa906b1AF7e",
+    "createdFromOwnerAddress": "",
+    "checksum": "0x065ee4e414f6926bbb6b34329e43ccf6d08dc87c49a5535ff8d7a969c86a1fd8"
+  },
+  "transactions": [
+    {
+      "to": "0x7AB124EC4029316c2A42F713828ddf2a192B36db",
+      "value": "0",
+      "data": null,
+      "contractMethod": {
+        "inputs": [
+          {
+            "internalType": "uint256",
+            "name": "rawEndValue",
+            "type": "uint256"
+          },
+          { "internalType": "uint256", "name": "endTime", "type": "uint256" }
+        ],
+        "name": "startAmplificationParameterUpdate",
+        "payable": false
+      },
+      "contractInputsValues": { "rawEndValue": "2000", "endTime": "1745021990" }
+    },
+    {
+      "to": "0xb2007B8B7E0260042517f635CFd8E6dD2Dd7f007",
+      "value": "0",
+      "data": null,
+      "contractMethod": {
+        "inputs": [
+          { "internalType": "address", "name": "pool", "type": "address" },
+          {
+            "internalType": "uint256",
+            "name": "newMaxSurgeSurgeFeePercentage",
+            "type": "uint256"
+          }
+        ],
+        "name": "setMaxSurgeFeePercentage",
+        "payable": false
+      },
+      "contractInputsValues": {
+        "pool": "0x7AB124EC4029316c2A42F713828ddf2a192B36db",
+        "newMaxSurgeSurgeFeePercentage": "50000000000000000"
+      }
+    },
+    {
+      "to": "0xb2007B8B7E0260042517f635CFd8E6dD2Dd7f007",
+      "value": "0",
+      "data": null,
+      "contractMethod": {
+        "inputs": [
+          { "internalType": "address", "name": "pool", "type": "address" },
+          {
+            "internalType": "uint256",
+            "name": "newSurgeThresholdPercentage",
+            "type": "uint256"
+          }
+        ],
+        "name": "setSurgeThresholdPercentage",
+        "payable": false
+      },
+      "contractInputsValues": {
+        "pool": "0x7AB124EC4029316c2A42F713828ddf2a192B36db",
+        "newSurgeThresholdPercentage": "50000000000000000"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Decreasing surge threshold and max fee to 5% per chat with Tokenlogic. Expectation is driving higher swap fees with a higher A factors as well due to routing pools going live using GHO.