### PR TITLE
vlaura vote report for 2025-W19

### DIFF
--- a/MaxiOps/vlaura_voting/2025/W19/output/payload.json
+++ b/MaxiOps/vlaura_voting/2025/W19/output/payload.json
@@ -1,0 +1,52 @@
+{
+    "domain": {
+        "name": "snapshot",
+        "version": "0.1.4"
+    },
+    "types": {
+        "Vote": [
+            {
+                "name": "from",
+                "type": "address"
+            },
+            {
+                "name": "space",
+                "type": "string"
+            },
+            {
+                "name": "timestamp",
+                "type": "uint64"
+            },
+            {
+                "name": "proposal",
+                "type": "bytes32"
+            },
+            {
+                "name": "choice",
+                "type": "string"
+            },
+            {
+                "name": "reason",
+                "type": "string"
+            },
+            {
+                "name": "app",
+                "type": "string"
+            },
+            {
+                "name": "metadata",
+                "type": "string"
+            }
+        ]
+    },
+    "message": {
+        "space": "gauges.aurafinance.eth",
+        "proposal": "0x5c74e4528d1dd2877440ddf172c9527e5a590841b7ce7ea33a95e9aed5c6691c",
+        "choice": "{\"107\":7.0,\"90\":5.0,\"240\":5.0,\"160\":10.0,\"239\":5.0,\"238\":5.0,\"162\":15.0,\"60\":7.0,\"85\":7.0,\"241\":5.0,\"237\":5.0,\"164\":12.0,\"163\":12.0}",
+        "app": "snapshot",
+        "reason": "",
+        "metadata": "{}",
+        "from": "0x9ff471F9f98F42E5151C7855fD1b5aa906b1AF7e",
+        "timestamp": 1745693358
+    }
+}

--- a/MaxiOps/vlaura_voting/2025/W19/output/payload.json
+++ b/MaxiOps/vlaura_voting/2025/W19/output/payload.json
@@ -1,52 +1,52 @@
 {
-    "domain": {
-        "name": "snapshot",
-        "version": "0.1.4"
-    },
-    "types": {
-        "Vote": [
-            {
-                "name": "from",
-                "type": "address"
-            },
-            {
-                "name": "space",
-                "type": "string"
-            },
-            {
-                "name": "timestamp",
-                "type": "uint64"
-            },
-            {
-                "name": "proposal",
-                "type": "bytes32"
-            },
-            {
-                "name": "choice",
-                "type": "string"
-            },
-            {
-                "name": "reason",
-                "type": "string"
-            },
-            {
-                "name": "app",
-                "type": "string"
-            },
-            {
-                "name": "metadata",
-                "type": "string"
-            }
-        ]
-    },
-    "message": {
-        "space": "gauges.aurafinance.eth",
-        "proposal": "0x5c74e4528d1dd2877440ddf172c9527e5a590841b7ce7ea33a95e9aed5c6691c",
-        "choice": "{\"107\":7.0,\"90\":5.0,\"240\":5.0,\"160\":10.0,\"239\":5.0,\"238\":5.0,\"162\":15.0,\"60\":7.0,\"85\":7.0,\"241\":5.0,\"237\":5.0,\"164\":12.0,\"163\":12.0}",
-        "app": "snapshot",
-        "reason": "",
-        "metadata": "{}",
-        "from": "0x9ff471F9f98F42E5151C7855fD1b5aa906b1AF7e",
-        "timestamp": 1745693358
-    }
+  "domain": {
+    "name": "snapshot",
+    "version": "0.1.4"
+  },
+  "types": {
+    "Vote": [
+      {
+        "name": "from",
+        "type": "address"
+      },
+      {
+        "name": "space",
+        "type": "string"
+      },
+      {
+        "name": "timestamp",
+        "type": "uint64"
+      },
+      {
+        "name": "proposal",
+        "type": "bytes32"
+      },
+      {
+        "name": "choice",
+        "type": "string"
+      },
+      {
+        "name": "reason",
+        "type": "string"
+      },
+      {
+        "name": "app",
+        "type": "string"
+      },
+      {
+        "name": "metadata",
+        "type": "string"
+      }
+    ]
+  },
+  "message": {
+    "space": "gauges.aurafinance.eth",
+    "proposal": "0x5c74e4528d1dd2877440ddf172c9527e5a590841b7ce7ea33a95e9aed5c6691c",
+    "choice": "{\"107\":7.0,\"90\":5.0,\"240\":5.0,\"160\":10.0,\"239\":5.0,\"238\":5.0,\"162\":15.0,\"60\":7.0,\"85\":7.0,\"241\":5.0,\"237\":5.0,\"164\":12.0,\"163\":12.0}",
+    "app": "snapshot",
+    "reason": "",
+    "metadata": "{}",
+    "from": "0x9ff471F9f98F42E5151C7855fD1b5aa906b1AF7e",
+    "timestamp": 1745693358
+  }
 }

--- a/MaxiOps/vlaura_voting/2025/W19/output/report.txt
+++ b/MaxiOps/vlaura_voting/2025/W19/output/report.txt
@@ -1,0 +1,2 @@
+hash: 0x7ad2789a9342a210f206d4ec615b66972ffafa11ba61c6b98acff0da31718bcc
+relayer: https://relayer.snapshot.org/api/messages/0x7ad2789a9342a210f206d4ec615b66972ffafa11ba61c6b98acff0da31718bcc

--- a/MaxiOps/vlaura_voting/2025/W19/output/vote_df.csv
+++ b/MaxiOps/vlaura_voting/2025/W19/output/vote_df.csv
@@ -1,0 +1,14 @@
+Chain,Label,Gauge Address,Allocation %,Unnamed: 4,Unnamed: 5,snapshot_label,snapshot_index,share
+Mainnet,V3 GHO/USDC/USDT,0x9fdD52eFEb601E4Bc78b89C6490505B8aC637E9f,7.00%,,,Stable waEthUSDT/Aave Prime GHO/waEthUSDC,107,7.0
+Mainnet,Lido fWETH-fwstETH,0x1cce9d493224a19fcb5f7fbade8478630141cb54,5.00%,,Reduce only alliance is in full swing (one more round max),Stable fwstETH/fWETH,90,5.0
+Base,Aave GHO-USDC,0x1da19f38eb6f2c22199dc0848118b26095c29aed,5.00%,,Last round,b-Stable waBasUSDC/waBasGHO,240,5.0
+Arbitrum,sUSDX-USDX-aUSDT,0xeb312b0d7795743C3DE905bc09c0D62aA180A7a6,10.00%,,,a-Stable waArbUSDT/USDX/sUSDX,160,10.0
+Base ,Aave GHO-USR,0xB1E8ec305b0b29097a117CaFC9721A553533E54C,5.00%,,Increase next round,b-Stable waBasGHO/waBasEURC,239,5.0
+Base,Aave GHO-EURC,0x1B7E33186C7e9C337508bB65EA9dc498aB14fcAE,5.00%,,Increase next round,b-Stable waBasGHO/USR,238,5.0
+Arbitrum,orbETH-aWETH,0x2D1c51eaB8b3c2287BA26061c0e339DA3b15B955,15.00%,,weeks 5 and 6 of 6 - LAST ROUND,a-Stable waArbWETH/orbETH,162,15.0
+Mainnet,wstETH-wETH,0xa8b309a75f0d64ed632d45a003c68a30e59a1d8b,7.00%,,Final round,ComposableStable WETH/ezETH,60,7.0
+Mainnet,rETH-wETH,0x79ef6103a513951a3b25743db509e267685726b7 ,7.00%,14.00%,Keep ,MetaStable rETH/WETH,85,7.0
+Base,Aave wETH-wstETH,0x0855e486EE80FF0EC7c913eC0588A7CBf2B8E89c,5.00%,,"Need arb TVL, Lido kicking can down the road on Base",b-Stable waBaswstETH/waBasWETH,241,5.0
+Base,Aave ezETH-wstETH,0x86C44de72Ec88d205E63c2aF8D577659319C7a7f,5.00%,,Upcoming stable pairs worthwhile? ,b-Stable waBasezETH/waBaswstETH,237,5.0
+Arbitrum,Aave wETH-wstETH,0xB2FcAd9fd42Affd0A90a996A1DEde4427435e5F8,12.00%,,,a-Stable waArbwstETH/waArbWETH,164,12.0
+Arbitrum,Aave ezETH-wstETH,0xCA318253Bb460e08ca33fD22574E7F70217130f5,12.00%,,,a-Stable waArbwstETH/waArbezETH,163,12.0


### PR DESCRIPTION
result from running: `tools/python/aura_snapshot_voting/vote.py --week-string 2025-W19` with hardcoded timestamp of `1745693358 ` and commenting out the `post_safe_tx` call