### PR TITLE
axlOP-Phase-1.5

### DIFF
--- a/MaxiOps/injectorScheduling/base/axlOP-5weeks-step1.json
+++ b/MaxiOps/injectorScheduling/base/axlOP-5weeks-step1.json
@@ -1,0 +1,198 @@
+{
+  "version": "1.0",
+  "chainId": "8453",
+  "createdAt": 1746634861485,
+  "meta": {
+    "name": "Transactions Batch",
+    "description": "",
+    "txBuilderVersion": "1.18.0",
+    "createdFromSafeAddress": "0x9ff471F9f98F42E5151C7855fD1b5aa906b1AF7e",
+    "createdFromOwnerAddress": "",
+    "checksum": "0xcee320919f7b57b1278cdcf8be3bb2617119db45b72800d975ef8d8f63b85c9c"
+  },
+  "transactions": [
+    {
+      "to": "0x9129E834e15eA19b6069e8f08a8EcFc13686B8dC",
+      "value": "0",
+      "data": null,
+      "contractMethod": {
+        "inputs": [
+          { "internalType": "address", "name": "target", "type": "address" },
+          { "internalType": "bytes", "name": "data", "type": "bytes" }
+        ],
+        "name": "performAction",
+        "payable": true
+      },
+      "contractInputsValues": {
+        "target": "0xed5c5357C219e82bba8E0D56B966684b58BECd74",
+        "data": "0xe8de0d4d000000000000000000000000994ac01750047B9d35431a7Ae4Ed312ee955E0300000000000000000000000006a71d17E50A67C54eae393323a8594cFdBb23F01"
+      }
+    },
+    {
+      "to": "0x9129E834e15eA19b6069e8f08a8EcFc13686B8dC",
+      "value": "0",
+      "data": null,
+      "contractMethod": {
+        "inputs": [
+          { "internalType": "address", "name": "target", "type": "address" },
+          { "internalType": "bytes", "name": "data", "type": "bytes" }
+        ],
+        "name": "performAction",
+        "payable": true
+      },
+      "contractInputsValues": {
+        "target": "0x50355F3Bb70317E518905664CE09333FA8b90645",
+        "data": "0xe8de0d4d000000000000000000000000994ac01750047B9d35431a7Ae4Ed312ee955E0300000000000000000000000006a71d17E50A67C54eae393323a8594cFdBb23F01"
+      }
+    },
+    {
+      "to": "0x9129E834e15eA19b6069e8f08a8EcFc13686B8dC",
+      "value": "0",
+      "data": null,
+      "contractMethod": {
+        "inputs": [
+          { "internalType": "address", "name": "target", "type": "address" },
+          { "internalType": "bytes", "name": "data", "type": "bytes" }
+        ],
+        "name": "performAction",
+        "payable": true
+      },
+      "contractInputsValues": {
+        "target": "0x70DB188E5953f67a4B16979a2ceA26248b315401",
+        "data": "0xe8de0d4d000000000000000000000000994ac01750047B9d35431a7Ae4Ed312ee955E0300000000000000000000000006a71d17E50A67C54eae393323a8594cFdBb23F01"
+      }
+    },
+    {
+      "to": "0x6a71d17E50A67C54eae393323a8594cFdBb23F01",
+      "value": "0",
+      "data": null,
+      "contractMethod": {
+        "inputs": [
+          {
+            "name": "recipients",
+            "type": "address[]",
+            "internalType": "address[]"
+          },
+          {
+            "name": "amountPerPeriod",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          { "name": "maxPeriods", "type": "uint8", "internalType": "uint8" },
+          {
+            "name": "doNotStartBeforeTimestamp",
+            "type": "uint56",
+            "internalType": "uint56"
+          }
+        ],
+        "name": "addRecipients",
+        "payable": false
+      },
+      "contractInputsValues": {
+        "recipients": "[0xec16621C9bD547d64B93c17B51838Ff173bB6DD1]",
+        "amountPerPeriod": "1500000000000000000000",
+        "maxPeriods": "5",
+        "doNotStartBeforeTimestamp": "1746634299"
+      }
+    },
+    {
+      "to": "0x6a71d17E50A67C54eae393323a8594cFdBb23F01",
+      "value": "0",
+      "data": null,
+      "contractMethod": {
+        "inputs": [
+          {
+            "name": "recipients",
+            "type": "address[]",
+            "internalType": "address[]"
+          },
+          {
+            "name": "amountPerPeriod",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          { "name": "maxPeriods", "type": "uint8", "internalType": "uint8" },
+          {
+            "name": "doNotStartBeforeTimestamp",
+            "type": "uint56",
+            "internalType": "uint56"
+          }
+        ],
+        "name": "addRecipients",
+        "payable": false
+      },
+      "contractInputsValues": {
+        "recipients": "[0xD8376B72E609A410999398b70218F70ae9B310F5, 0x80db733644C60E891b3C7a96141430e4bAafF028, 0x50355f3bb70317e518905664ce09333fa8b90645]",
+        "amountPerPeriod": "700000000000000000000",
+        "maxPeriods": "5",
+        "doNotStartBeforeTimestamp": "1746634299"
+      }
+    },
+    {
+      "to": "0x6a71d17E50A67C54eae393323a8594cFdBb23F01",
+      "value": "0",
+      "data": null,
+      "contractMethod": {
+        "inputs": [
+          {
+            "name": "recipients",
+            "type": "address[]",
+            "internalType": "address[]"
+          },
+          {
+            "name": "amountPerPeriod",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          { "name": "maxPeriods", "type": "uint8", "internalType": "uint8" },
+          {
+            "name": "doNotStartBeforeTimestamp",
+            "type": "uint56",
+            "internalType": "uint56"
+          }
+        ],
+        "name": "addRecipients",
+        "payable": false
+      },
+      "contractInputsValues": {
+        "recipients": "[0x70db188e5953f67a4b16979a2cea26248b315401]",
+        "amountPerPeriod": "1750000000000000000000",
+        "maxPeriods": "5",
+        "doNotStartBeforeTimestamp": "1746634299"
+      }
+    },
+    {
+      "to": "0x6a71d17E50A67C54eae393323a8594cFdBb23F01",
+      "value": "0",
+      "data": null,
+      "contractMethod": {
+        "inputs": [
+          {
+            "name": "recipients",
+            "type": "address[]",
+            "internalType": "address[]"
+          },
+          {
+            "name": "amountPerPeriod",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          { "name": "maxPeriods", "type": "uint8", "internalType": "uint8" },
+          {
+            "name": "doNotStartBeforeTimestamp",
+            "type": "uint56",
+            "internalType": "uint56"
+          }
+        ],
+        "name": "addRecipients",
+        "payable": false
+      },
+      "contractInputsValues": {
+        "recipients": "[0xed5c5357C219e82bba8E0D56B966684b58BECd74]",
+        "amountPerPeriod": "412500000000000000000",
+        "maxPeriods": "4",
+        "doNotStartBeforeTimestamp": "1747312200"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Encompasses majority of the planned axlOP incentive plan on Base through June 12th. Additional to this program QuantAMM direct incentives and ReCLAMM direct incentives will need to be added as gauges become available for those pools.

[Sheet](https://docs.google.com/spreadsheets/d/1894FY9zEPAsNxbiTSPp4N2NqsI8thzeIu6jQXkSBmZI/edit?gid=0#gid=0)

All GHO, yUSD, MEV tax and Akron swap pools are finalized through this program until the end of the program.

Akron swap will not start until May 15th per Mike, hence the later timestamp.