### PR TITLE
Update Surge Threshold to 30% for USR and USDC - GHO pools on Base

### DIFF
--- a/MaxiOps/PoolParameterChanges/PoolStableSurgeParams/Base/USR-USDC-GHO-SurgeUpdate-30Percent.json
+++ b/MaxiOps/PoolParameterChanges/PoolStableSurgeParams/Base/USR-USDC-GHO-SurgeUpdate-30Percent.json
@@ -1,0 +1,62 @@
+{
+  "version": "1.0",
+  "chainId": "8453",
+  "createdAt": 1746704971386,
+  "meta": {
+    "name": "Transactions Batch",
+    "description": "Set surge threshold to 30% for pool 0x7ab124ec4029316c2a42f713828ddf2a192b36db",
+    "createdFromSafeAddress": "0x9ff471F9f98F42E5151C7855fD1b5aa906b1AF7e"
+  },
+  "transactions": [
+    {
+      "to": "0xb2007b8b7e0260042517f635cfd8e6dd2dd7f007",
+      "value": "0",
+      "data": null,
+      "contractMethod": {
+        "inputs": [
+          {
+            "internalType": "address",
+            "name": "pool",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "newSurgeThresholdPercentage",
+            "type": "uint256"
+          }
+        ],
+        "name": "setSurgeThresholdPercentage",
+        "payable": false
+      },
+      "contractInputsValues": {
+        "pool": "0x7ab124ec4029316c2a42f713828ddf2a192b36db",
+        "newSurgeThresholdPercentage": "300000000000000000"
+      }
+    },
+    {
+      "to": "0xb2007b8b7e0260042517f635cfd8e6dd2dd7f007",
+      "value": "0",
+      "data": null,
+      "contractMethod": {
+        "inputs": [
+          {
+            "internalType": "address",
+            "name": "pool",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "newSurgeThresholdPercentage",
+            "type": "uint256"
+          }
+        ],
+        "name": "setSurgeThresholdPercentage",
+        "payable": false
+      },
+      "contractInputsValues": {
+        "pool": "0x5b14ce8de84448e9a6f6af652af318472aa4fcaf",
+        "newSurgeThresholdPercentage": "300000000000000000"
+      }
+    }
+  ]
+}

--- a/MaxiOps/PoolParameterChanges/PoolStableSurgeParams/Base/USR-USDC-GHO-SurgeUpdate-30Percent.report.txt
+++ b/MaxiOps/PoolParameterChanges/PoolStableSurgeParams/Base/USR-USDC-GHO-SurgeUpdate-30Percent.report.txt
@@ -1,0 +1,28 @@
+FILENAME: `MaxiOps/PoolParameterChanges/PoolStableSurgeParams/Base/USR-USDC-GHO-SurgeUpdate-30Percent.json`
+MULTISIG: `multisigs/maxi_omni (base:0x9ff471F9f98F42E5151C7855fD1b5aa906b1AF7e)`
+COMMIT: `7f4a8556974fad5007b3268684f1e870b8fb8674`
+CHAIN(S): `base`
+TENDERLY: [`🟩 SUCCESS`](https://www.tdly.co/shared/simulation/5fcf44f7-9b1d-4732-8210-9776ebd9b3a9)
+
+```
++-----------------------------+---------------------------------------------------------------------------------------+-------+----------------------------------------------------------------------------------+------------+----------+
+| fx_name                     | to                                                                                    | value | inputs                                                                           | bip_number | tx_index |
++-----------------------------+---------------------------------------------------------------------------------------+-------+----------------------------------------------------------------------------------+------------+----------+
+| setSurgeThresholdPercentage | 0xb2007b8b7e0260042517f635cfd8e6dd2dd7f007 (20250121-v3-stable-surge/StableSurgeHook) | 0     | {                                                                                | N/A        |   N/A    |
+|                             |                                                                                       |       |   "pool": [                                                                      |            |          |
+|                             |                                                                                       |       |     "0x7ab124ec4029316c2a42f713828ddf2a192b36db (pools/Aave USDC-Aave GHO-7ab1)" |            |          |
+|                             |                                                                                       |       |   ],                                                                             |            |          |
+|                             |                                                                                       |       |   "newSurgeThresholdPercentage": [                                               |            |          |
+|                             |                                                                                       |       |     "300000000000000000"                                                         |            |          |
+|                             |                                                                                       |       |   ]                                                                              |            |          |
+|                             |                                                                                       |       | }                                                                                |            |          |
+| setSurgeThresholdPercentage | 0xb2007b8b7e0260042517f635cfd8e6dd2dd7f007 (20250121-v3-stable-surge/StableSurgeHook) | 0     | {                                                                                | N/A        |   N/A    |
+|                             |                                                                                       |       |   "pool": [                                                                      |            |          |
+|                             |                                                                                       |       |     "0x5b14ce8de84448e9a6f6af652af318472aa4fcaf (pools/Aave GHO-USR-5b14)"       |            |          |
+|                             |                                                                                       |       |   ],                                                                             |            |          |
+|                             |                                                                                       |       |   "newSurgeThresholdPercentage": [                                               |            |          |
+|                             |                                                                                       |       |     "300000000000000000"                                                         |            |          |
+|                             |                                                                                       |       |   ]                                                                              |            |          |
+|                             |                                                                                       |       | }                                                                                |            |          |
++-----------------------------+---------------------------------------------------------------------------------------+-------+----------------------------------------------------------------------------------+------------+----------+
+```

--- a/MaxiOps/vlaura_voting/2025/W21/output/payload.json
+++ b/MaxiOps/vlaura_voting/2025/W21/output/payload.json
@@ -1,52 +1,52 @@
 {
-    "domain": {
-        "name": "snapshot",
-        "version": "0.1.4"
-    },
-    "types": {
-        "Vote": [
-            {
-                "name": "from",
-                "type": "address"
-            },
-            {
-                "name": "space",
-                "type": "string"
-            },
-            {
-                "name": "timestamp",
-                "type": "uint64"
-            },
-            {
-                "name": "proposal",
-                "type": "bytes32"
-            },
-            {
-                "name": "choice",
-                "type": "string"
-            },
-            {
-                "name": "reason",
-                "type": "string"
-            },
-            {
-                "name": "app",
-                "type": "string"
-            },
-            {
-                "name": "metadata",
-                "type": "string"
-            }
-        ]
-    },
-    "message": {
-        "space": "gauges.aurafinance.eth",
-        "proposal": "0x10350cb7cc6e6758c15dd0616e0ec58d4045e17312014a3234451bd9d8248dcf",
-        "choice": "{\"87\":7.0,\"93\":5.0,\"241\":10.0,\"160\":5.0,\"239\":5.0,\"238\":5.0,\"253\":10.0,\"85\":7.0,\"165\":15.0,\"162\":10.0,\"251\":9.0,\"250\":7.0,\"249\":5.0}",
-        "app": "snapshot",
-        "reason": "",
-        "metadata": "{}",
-        "from": "0x9ff471F9f98F42E5151C7855fD1b5aa906b1AF7e",
-        "timestamp": 1746697394
-    }
+  "domain": {
+    "name": "snapshot",
+    "version": "0.1.4"
+  },
+  "types": {
+    "Vote": [
+      {
+        "name": "from",
+        "type": "address"
+      },
+      {
+        "name": "space",
+        "type": "string"
+      },
+      {
+        "name": "timestamp",
+        "type": "uint64"
+      },
+      {
+        "name": "proposal",
+        "type": "bytes32"
+      },
+      {
+        "name": "choice",
+        "type": "string"
+      },
+      {
+        "name": "reason",
+        "type": "string"
+      },
+      {
+        "name": "app",
+        "type": "string"
+      },
+      {
+        "name": "metadata",
+        "type": "string"
+      }
+    ]
+  },
+  "message": {
+    "space": "gauges.aurafinance.eth",
+    "proposal": "0x10350cb7cc6e6758c15dd0616e0ec58d4045e17312014a3234451bd9d8248dcf",
+    "choice": "{\"87\":7.0,\"93\":5.0,\"241\":10.0,\"160\":5.0,\"239\":5.0,\"238\":5.0,\"253\":10.0,\"85\":7.0,\"165\":15.0,\"162\":10.0,\"251\":9.0,\"250\":7.0,\"249\":5.0}",
+    "app": "snapshot",
+    "reason": "",
+    "metadata": "{}",
+    "from": "0x9ff471F9f98F42E5151C7855fD1b5aa906b1AF7e",
+    "timestamp": 1746697394
+  }
 }


### PR DESCRIPTION
- As per MG request, new surge threshold percentage params from 10 to 30% to facilitate big trades with lower slippage
![image](https://github.com/user-attachments/assets/03337b14-dcd0-4881-8427-9b8f5c10d755)
