### PR TITLE
Balancer Alliance: Add eligible Lido pools

### DIFF
--- a/config/alliance_fee_share.json
+++ b/config/alliance_fee_share.json
@@ -14,6 +14,30 @@
           "pool_type": "core",
           "eligibility_date": "2025-04-15",
           "active": true
+        },
+        {
+          "pool_id": "0x5418a64e0cdb20548ACB394f5D00a089BAf02161",
+          "network": "arbitrum",
+          "partner": "Rocket Pool",
+          "pool_type": "core",
+          "eligibility_date": "2025-06-04",
+          "active": true
+        },
+        {
+          "pool_id": "0x870c0Af8A1af0B58b4b0bD31CE4fe72864ae45BE",
+          "network": "optimism",
+          "partner": "Rocket Pool",
+          "pool_type": "core",
+          "eligibility_date": "2025-06-04",
+          "active": true
+        },
+        {
+          "pool_id": "0xB7B8B3AfC010169779C5C2385ec0eB0477FE3347",
+          "network": "base",
+          "partner": "Rocket Pool",
+          "pool_type": "core",
+          "eligibility_date": "2025-06-04",
+          "active": true
         }
       ]
     },
@@ -30,6 +54,30 @@
           "partner": "Lido",
           "pool_type": "core",
           "eligibility_date": "2025-05-19",
+          "active": true
+        },
+        {
+          "pool_id": "0x6b31a94029fd7840d780191b6d63fa0d269bd883",
+          "network": "mainnet",
+          "partner": "Lido",
+          "pool_type": "core",
+          "eligibility_date": "2025-06-04",
+          "active": true
+        },
+        {
+          "pool_id": "0xb1b8b406eeebbb636fdbb20e6732c117d828363c",
+          "network": "arbitrum",
+          "partner": "Lido",
+          "pool_type": "core",
+          "eligibility_date": "2025-06-04",
+          "active": true
+        },
+        {
+          "pool_id": "0x9972c4f21b5ae6062233031314adbbdda7513ed2",
+          "network": "base",
+          "partner": "Lido",
+          "pool_type": "core",
+          "eligibility_date": "2025-06-04",
           "active": true
         }
       ]

--- a/config/alliance_fee_share.json
+++ b/config/alliance_fee_share.json
@@ -48,7 +48,8 @@
       "dao_share_pct": 0.175
     },
     "alliance_thresholds": {
-      "min_tvl": 5000000
+      "v3_min_tvl": 5000000,
+      "v2_min_tvl": 0
     }
   }
 }

--- a/config/alliance_fee_share.json
+++ b/config/alliance_fee_share.json
@@ -46,6 +46,9 @@
       "vebal_share_pct": 0.65,
       "partner_share_pct": 0.175,
       "dao_share_pct": 0.175
+    },
+    "alliance_thresholds": {
+      "min_tvl": 5000000
     }
   }
 }

--- a/config/alliance_fee_share.json
+++ b/config/alliance_fee_share.json
@@ -16,6 +16,23 @@
           "active": true
         }
       ]
+    },
+    {
+      "name": "Lido",
+      "multisig_address": "0x87D93d9B2C672bf9c9642d853a8682546a5012B5",
+      "active": true,
+      "join_date": "2025-05-19",
+      "last_lock_date": "2025-05-19",
+      "pools": [
+        {
+          "pool_id": "0x93d199263632a4ef4bb438f1feb99e57b4b5f0bd0000000000000000000005c2",
+          "network": "mainnet",
+          "partner": "Lido",
+          "pool_type": "core",
+          "eligibility_date": "2025-05-19",
+          "active": true
+        }
+      ]
     }
   ],
   "alliance_fee_allocations": {

--- a/config/alliance_fee_share.json
+++ b/config/alliance_fee_share.json
@@ -46,10 +46,10 @@
       "vebal_share_pct": 0.65,
       "partner_share_pct": 0.175,
       "dao_share_pct": 0.175
-    },
-    "alliance_thresholds": {
-      "v3_min_tvl": 5000000,
-      "v2_min_tvl": 0
     }
+  },
+  "alliance_thresholds": {
+    "v3_min_tvl": 5000000,
+    "v2_min_tvl": 0
   }
 }


### PR DESCRIPTION
- [Proposal](https://snapshot.box/#/s:balancer.eth/proposal/0x212dcd5b0e698c52bb9ae9c09d928d91850628b7ed636ecba30d3cdc6350b826)
- Currently only the v2 pool is eligible
- V3 pools didn't hit 5mln threshold yet, nor did Lido place voting incentives

I also created https://github.com/BalancerMaxis/multisig-ops/issues/2078 to address automatic verification if the pool list is indeed correct based on the Alliance param set