### PR TITLE
Revert "chore(deps): bump creyD/prettier_action from 4.5 to 4.6"

### DIFF
--- a/.github/workflows/run_reports_reusable.yaml
+++ b/.github/workflows/run_reports_reusable.yaml
@@ -111,7 +111,7 @@ jobs:
           pr-number: ${{ inputs.pr_number }}
 
       - name: Prettify code
-        uses: creyD/prettier_action@v4.6
+        uses: creyD/prettier_action@v4.5
         with:
           # This part is also where you can pass other options, for example:
           prettier_options: --write BIPs/**/*.json config/*.json MaxiOps/**/*.json


### PR DESCRIPTION
Reverts BalancerMaxis/multisig-ops#2108

eg https://github.com/BalancerMaxis/multisig-ops/actions/runs/15559208156/job/43807381737

```
Run creyD/prettier_action@v4.6
Run PATH=$GITHUB_ACTION_PATH/node_modules/.bin:$PATH /home/runner/work/_actions/creyD/prettier_action/v4.6/entrypoint.sh
Installing prettier...
Prettifying files...
Files:
npm warn exec The following package was not found and will be installed: prettier@3.5.3
```