### PR TITLE
Cancel Zen Dragons sUSDS Stream

### DIFF
--- a/MaxiOps/sablier/cancel-zen-dragon.json
+++ b/MaxiOps/sablier/cancel-zen-dragon.json
@@ -1,0 +1,59 @@
+{
+  "version": "1.0",
+  "chainId": "1",
+  "createdAt": 1750150920061,
+  "meta": {
+    "name": "Transactions Batch",
+    "description": "",
+    "txBuilderVersion": "1.18.0",
+    "createdFromSafeAddress": "0x166f54F44F271407f24AA1BE415a730035637325",
+    "createdFromOwnerAddress": "",
+    "checksum": "0xe62ea4728573ece7d50cad6ce5d0b85eaed179d0c3f88f0b8ccaf8a9ebb2764d"
+  },
+  "transactions": [
+    {
+      "to": "0x7c01aa3783577e15fd7e272443d44b92d5b21056",
+      "value": "0",
+      "data": null,
+      "contractMethod": {
+        "inputs": [
+          {
+            "name": "streamId",
+            "type": "uint256",
+            "internalType": "uint256"
+          }
+        ],
+        "name": "cancel",
+        "payable": false
+      },
+      "contractInputsValues": {
+        "streamId": "3549"
+      }
+    },
+    {
+      "to": "0x7c01aa3783577e15fd7e272443d44b92d5b21056",
+      "value": "0",
+      "data": null,
+      "contractMethod": {
+        "inputs": [
+          {
+            "name": "streamId",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "to",
+            "type": "address",
+            "internalType": "address"
+          }
+        ],
+        "name": "withdrawMax",
+        "payable": false
+      },
+      "contractInputsValues": {
+        "streamId": "3549",
+        "to": "0xe743449d33f2f330a46dbc050565239f5df8805a"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
- cancels stream
- withdraws all claimable sUSDS to Zen
- Zen needs to pay back diff between June 15th 23:59 and the execution of this payload which will be calculated thereafter