### PR TITLE
replace maxi omni with aura locker

### DIFF
--- a/tools/python/aura_snapshot_voting/vote.py
+++ b/tools/python/aura_snapshot_voting/vote.py
@@ -190,7 +190,7 @@ if __name__ == "__main__":
     print(f"hash: {hash.hex()}")
 
     calldata = Web3.keccak(text="signMessage(bytes)")[0:4] + encode(["bytes"], [hash])
-    exit()
+
     post_safe_tx(
         vlaura_safe_addr, sign_msg_lib_addr, 0, calldata, Operation.DELEGATE_CALL
     )


### PR DESCRIPTION
#2121

replaced only in vlaura vote script

there are two other instances of maxi_omni being used:

- here in recycle bribes script (i think this can stay for last run this week?): https://github.com/BalancerMaxis/multisig-ops/blob/a68c919097a6dd7aa7710340e5ad8d38d9b385a3/tools/python/paladin_claiming/recycle_bribes.py#L33
- and in fee bot: https://github.com/BalancerMaxis/multisig-ops/blob/a68c919097a6dd7aa7710340e5ad8d38d9b385a3/action-scripts/v3_fee_bot.py#L20