### PR TITLE
ci: run fee bot every midnight

### DIFF
--- a/.github/workflows/v3_fee_bot.yaml
+++ b/.github/workflows/v3_fee_bot.yaml
@@ -1,6 +1,9 @@
 name: V3 Fee Bot
 
 on:
+  schedule:
+    # Run daily at midnight UTC
+    - cron: '0 0 * * *'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
requires removal of the review mechanism from the `v3-fee-bot` environment