### PR TITLE
add new partner config

### DIFF
--- a/config/alliance_fee_share.json
+++ b/config/alliance_fee_share.json
@@ -83,6 +83,53 @@
       ]
     }
   ],
+  "partners": [
+    {
+      "name": "QuantAMM",
+      "multisig_address": "0x0000000000000000000000000000000000000001",
+      "active": true,
+      "pools": [
+        {
+          "pool_id": "0x05ff47afada98a98982113758878f9a8b9fdda0a000000000000000000000645",
+          "network": "mainnet",
+          "eligibility_date": "2025-06-01",
+          "active": true
+        }
+      ],
+      "custom_fee_allocation": {
+        "vebal_share_pct": 0.10,
+        "vote_incentive_pct": 0.20,
+        "partner_share_pct": 0.60,
+        "dao_share_pct": 0.10
+      }
+    },
+    {
+      "name": "TestPartner",
+      "multisig_address": "0x0000000000000000000000000000000000000002",
+      "active": true,
+      "pools": [
+        {
+          "pool_id": "0x1d13531bf6344c102280ce4c458781fbf14dad140000000000000000000006df",
+          "network": "mainnet",
+          "eligibility_date": "2025-06-01",
+          "active": true
+        }
+      ]
+    },
+    {
+      "name": "NonCorePartner",
+      "multisig_address": "0x0000000000000000000000000000000000000003",
+      "active": true,
+      "pools": [
+        {
+          "pool_id": "0xb986fd52697f16be888bfad2c5bf12cd67ce834b000200000000000000000634",
+          "network": "mainnet",
+          "eligibility_date": "2025-06-01",
+          "active": true
+        }
+      ]
+    }
+  ],
   "alliance_fee_allocations": {
     "core": {
       "vebal_share_pct": 0.125,
@@ -93,6 +140,19 @@
     "non_core": {
       "vebal_share_pct": 0.65,
       "partner_share_pct": 0.175,
+      "dao_share_pct": 0.175
+    }
+  },
+  "partner_fee_allocations": {
+    "default": {
+      "vebal_share_pct": 0.125,
+      "vote_incentive_pct": 0.35,
+      "partner_share_pct": 0.35,
+      "dao_share_pct": 0.175
+    },
+    "default_non_core": {
+      "vebal_share_pct": 0.475,
+      "partner_share_pct": 0.35,
       "dao_share_pct": 0.175
     }
   },


### PR DESCRIPTION
adds a new "partner" structure to the alliance_fee_share config that makes a distinction between "partners" and "alliance" pools. 

**alliance** - pools that are part of the alliance program
**partner** - pools that need to have a custom fee split but *aren't* part of the alliance program.

contains placeholder pools for now for testing