### PR TITLE
ci: use sha for external branches prs

### DIFF
--- a/.github/workflows/black.yaml
+++ b/.github/workflows/black.yaml
@@ -9,7 +9,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.head_ref }}
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Black
         uses: psf/black@stable


### PR DESCRIPTION
see https://github.com/BalancerMaxis/multisig-ops/actions/runs/16826878377