### PR TITLE
Add RZR to the lstRZR and weETH balancer pools on ETH Mainnet

### DIFF
--- a/MaxiOps/add_rewards/ethereum/add-RZR-to-weETH-lstRZR-gauge.json
+++ b/MaxiOps/add_rewards/ethereum/add-RZR-to-weETH-lstRZR-gauge.json
@@ -1,0 +1,61 @@
+{
+  "version": "1.0",
+  "chainId": "1",
+  "createdAt": 1756221664942,
+  "meta": {
+    "name": "Transactions Batch",
+    "createdFromSafeAddress": "0x9ff471F9f98F42E5151C7855fD1b5aa906b1AF7e"
+  },
+  "transactions": [
+    {
+      "to": "0xf5dECDB1f3d1ee384908Fbe16D2F0348AE43a9eA",
+      "value": "0",
+      "data": null,
+      "contractMethod": {
+        "inputs": [
+          {
+            "internalType": "address",
+            "name": "target",
+            "type": "address"
+          },
+          {
+            "internalType": "bytes",
+            "name": "data",
+            "type": "bytes"
+          }
+        ],
+        "name": "performAction",
+        "payable": true
+      },
+      "contractInputsValues": {
+        "target": "0x320216774426b2765c72ab1ea9606d1474adf677",
+        "data": "0xe8de0d4d000000000000000000000000b4444468e444f89e1c2cac2f1d3ee7e336cbd1f5000000000000000000000000E2E45c8747133D32Adb732abaBCf25d800A8513d"
+      }
+    },
+    {
+      "to": "0xf5dECDB1f3d1ee384908Fbe16D2F0348AE43a9eA",
+      "value": "0",
+      "data": null,
+      "contractMethod": {
+        "inputs": [
+          {
+            "internalType": "address",
+            "name": "target",
+            "type": "address"
+          },
+          {
+            "internalType": "bytes",
+            "name": "data",
+            "type": "bytes"
+          }
+        ],
+        "name": "performAction",
+        "payable": true
+      },
+      "contractInputsValues": {
+        "target": "0x69bd054863dbf43a42189665dbd4060d2c07a2c8",
+        "data": "0xe8de0d4d000000000000000000000000b4444468e444f89e1c2cac2f1d3ee7e336cbd1f5000000000000000000000000E2E45c8747133D32Adb732abaBCf25d800A8513d"
+      }
+    }
+  ]
+}

--- a/MaxiOps/add_rewards/ethereum/add-RZR-to-weETH-lstRZR-gauge.report.txt
+++ b/MaxiOps/add_rewards/ethereum/add-RZR-to-weETH-lstRZR-gauge.report.txt
@@ -1,8 +1,8 @@
 FILENAME: `MaxiOps/add_rewards/ethereum/add-RZR-to-weETH-lstRZR-gauge.json`
 MULTISIG: `multisigs/maxi_omni (mainnet:0x9ff471F9f98F42E5151C7855fD1b5aa906b1AF7e)`
-COMMIT: `e6f8c5e92bcc50971610270734e77f0be8e784b8`
+COMMIT: `2aa5627ffed57098044d857885b36b60ddaf92d6`
 CHAIN(S): `mainnet`
-TENDERLY: [`🟩 SUCCESS`](https://www.tdly.co/shared/simulation/69e9d5b7-c53f-447d-98b0-35c1b20b151c)
+TENDERLY: [`🟩 SUCCESS`](https://www.tdly.co/shared/simulation/ab62459f-2c61-4dd7-82f4-d611cab4d7e4)
 
 ```
 +---------------+-----------------------------------------------------------------------------------------------------------------+---------------------------------------------------------------------------+-----------------------------+--------------------------------------------------------------------------+-----+----------+

--- a/MaxiOps/add_rewards/ethereum/add-RZR-to-weETH-lstRZR-gauge.report.txt
+++ b/MaxiOps/add_rewards/ethereum/add-RZR-to-weETH-lstRZR-gauge.report.txt
@@ -1,0 +1,16 @@
+FILENAME: `MaxiOps/add_rewards/ethereum/add-RZR-to-weETH-lstRZR-gauge.json`
+MULTISIG: `multisigs/maxi_omni (mainnet:0x9ff471F9f98F42E5151C7855fD1b5aa906b1AF7e)`
+COMMIT: `e6f8c5e92bcc50971610270734e77f0be8e784b8`
+CHAIN(S): `mainnet`
+TENDERLY: [`🟩 SUCCESS`](https://www.tdly.co/shared/simulation/69e9d5b7-c53f-447d-98b0-35c1b20b151c)
+
+```
++---------------+-----------------------------------------------------------------------------------------------------------------+---------------------------------------------------------------------------+-----------------------------+--------------------------------------------------------------------------+-----+----------+
+| function      | entrypoint                                                                                                      | target                                                                    | selector                    | parsed_inputs                                                            | bip | tx_index |
++---------------+-----------------------------------------------------------------------------------------------------------------+---------------------------------------------------------------------------+-----------------------------+--------------------------------------------------------------------------+-----+----------+
+| performAction | 0xf5dECDB1f3d1ee384908Fbe16D2F0348AE43a9eA (20221124-authorizer-adaptor-entrypoint/AuthorizerAdaptorEntrypoint) | 0x320216774426b2765c72ab1ea9606d1474adf677 (gauges/RZR-weETH-gauge-3202)  | add_reward(address,address) | 0xb4444468e444f89e1c2CAc2F1D3ee7e336cBD1f5: RZR                          | N/A |    0     |
+|               |                                                                                                                 |                                                                           |                             | 0xE2E45c8747133D32Adb732abaBCf25d800A8513d: rezerve/rzr_rewards_injector |     |          |
+| performAction | 0xf5dECDB1f3d1ee384908Fbe16D2F0348AE43a9eA (20221124-authorizer-adaptor-entrypoint/AuthorizerAdaptorEntrypoint) | 0x69bd054863dbf43a42189665dbd4060d2c07a2c8 (gauges/RZR-lstRZR-gauge-69bd) | add_reward(address,address) | 0xb4444468e444f89e1c2CAc2F1D3ee7e336cBD1f5: RZR                          | N/A |    1     |
+|               |                                                                                                                 |                                                                           |                             | 0xE2E45c8747133D32Adb732abaBCf25d800A8513d: rezerve/rzr_rewards_injector |     |          |
++---------------+-----------------------------------------------------------------------------------------------------------------+---------------------------------------------------------------------------+-----------------------------+--------------------------------------------------------------------------+-----+----------+
+```


### PR DESCRIPTION
The Maxi Multisig 0x9ff471F9f98F42E5151C7855fD1b5aa906b1AF7e will interact with the following gauges: Add Reward:

Target (Gauge Address): 0x320216774426b2765c72ab1ea9606d1474adf677 To (Authorizer Adaptor Entrypoint): 0xf5dECDB1f3d1ee384908Fbe16D2F0348AE43a9eA

Target (Gauge Address): 0x69bd054863dbf43a42189665dbd4060d2c07a2c8 To (Authorizer Adaptor Entrypoint): 0xf5dECDB1f3d1ee384908Fbe16D2F0348AE43a9eA

Reward Token: 0xb4444468e444f89e1c2cac2f1d3ee7e336cbd1f5 Distributor Address: 0xe2e45c8747133d32adb732ababcf25d800a8513d

Payload was made using the https://balancer.defilytica.tools/payload-builder/add-reward-to-gauge script

Pools

- RZR/weETH - https://balancer.fi/pools/ethereum/v3/0x3f89f8c0e0ffdfae0b97959303831fa893f1cfe0
- RZR/lstRZR - https://balancer.fi/pools/ethereum/v3/0xecd03277a21e41bd61c9226eba24930a6a54b30c
