### PR TITLE
QI Rewards Program Config

### DIFF
--- a/MaxiOps/injectorScheduling/avalanche/QI-acceptOwnership-Rewards-config.json
+++ b/MaxiOps/injectorScheduling/avalanche/QI-acceptOwnership-Rewards-config.json
@@ -1,0 +1,63 @@
+{
+  "version": "1.0",
+  "chainId": "43114",
+  "createdAt": 1756727710014,
+  "meta": {
+    "name": "Transactions Batch",
+    "description": "",
+    "txBuilderVersion": "1.18.0",
+    "createdFromSafeAddress": "0x9ff471F9f98F42E5151C7855fD1b5aa906b1AF7e",
+    "createdFromOwnerAddress": "",
+    "checksum": "0xe219c45c019045282065c84259da569d2cc8fa8a131bb4400c69794b60ece5b9"
+  },
+  "transactions": [
+    {
+      "to": "0x08F02E2945C175272Acbb238ACCB6eda56129DE8",
+      "value": "0",
+      "data": null,
+      "contractMethod": {
+        "inputs": [],
+        "name": "acceptOwnership",
+        "payable": false
+      },
+      "contractInputsValues": null
+    },
+    {
+      "to": "0x08F02E2945C175272Acbb238ACCB6eda56129DE8",
+      "value": "0",
+      "data": null,
+      "contractMethod": {
+        "inputs": [
+          {
+            "name": "recipients",
+            "type": "address[]",
+            "internalType": "address[]"
+          },
+          {
+            "name": "amountPerPeriod",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "maxPeriods",
+            "type": "uint8",
+            "internalType": "uint8"
+          },
+          {
+            "name": "doNotStartBeforeTimestamp",
+            "type": "uint56",
+            "internalType": "uint56"
+          }
+        ],
+        "name": "addRecipients",
+        "payable": false
+      },
+      "contractInputsValues": {
+        "recipients": "[0x746db23a0b49e002697fad244c281a36b86b1b01]",
+        "amountPerPeriod": "250000000000000000000000",
+        "maxPeriods": "4",
+        "doNotStartBeforeTimestamp": "1756818000"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
- Accept ownership
- Configure 250k QI for 4 weeks to tAVAX:sAVAX gauge on Avalanche, see [program request](https://docs.google.com/spreadsheets/d/1rO7crwwGI4KyCUZOc4irI2uYLiJgl4pbQanQQon6F_I/edit?gid=0#gid=0)
- Upkeeper set up and funded:  https://automation.chain.link/avalanche/8927429550892741296436939422788889080084711594155681525507859383597389306224