### PR TITLE
LM Multisig Clean-up: Dust

### DIFF
--- a/MaxiOps/LM_Cleanup/arbitrum_dust_transfers.json
+++ b/MaxiOps/LM_Cleanup/arbitrum_dust_transfers.json
@@ -1,0 +1,67 @@
+{
+  "version": "1.0",
+  "chainId": "42161",
+  "createdAt": 1735826000000,
+  "meta": {
+    "name": "Arbitrum Token Transfers to gosuto_deployer",
+    "description": "Transfer LINK (12.559586162296156085) to Omni, USDT (25.13491), and ETH (0.001) to gosuto_deployer",
+    "txBuilderVersion": "1.17.0",
+    "createdFromSafeAddress": "0xc38c5f97B34E175FFd35407fc91a937300E33860",
+    "createdFromOwnerAddress": ""
+  },
+  "transactions": [
+    {
+      "to": "0xf97f4df75117a78c1a5a0dbb814af92458539fb4",
+      "value": "0",
+      "data": null,
+      "contractMethod": {
+        "inputs": [
+          {
+            "name": "to",
+            "type": "address"
+          },
+          {
+            "name": "value",
+            "type": "uint256"
+          }
+        ],
+        "name": "transfer",
+        "payable": false
+      },
+      "contractInputsValues": {
+        "to": "0x9ff471F9f98F42E5151C7855fD1b5aa906b1AF7e",
+        "value": "12559586162296156085"
+      }
+    },
+    {
+      "to": "0xfd086bc7cd5c481dcc9c85ebe478a1c0b69fcbb9",
+      "value": "0",
+      "data": null,
+      "contractMethod": {
+        "inputs": [
+          {
+            "name": "_to",
+            "type": "address"
+          },
+          {
+            "name": "_value",
+            "type": "uint256"
+          }
+        ],
+        "name": "transfer",
+        "payable": false
+      },
+      "contractInputsValues": {
+        "_to": "0x4BC8121278056BFCaC2BD14D455659224d6dDf48",
+        "_value": "25134910"
+      }
+    },
+    {
+      "to": "0x4BC8121278056BFCaC2BD14D455659224d6dDf48",
+      "value": "1000000000000000",
+      "data": null,
+      "contractMethod": null,
+      "contractInputsValues": null
+    }
+  ]
+}

--- a/MaxiOps/LM_Cleanup/avalanche_dust_transfers.json
+++ b/MaxiOps/LM_Cleanup/avalanche_dust_transfers.json
@@ -1,0 +1,44 @@
+{
+  "version": "1.0",
+  "chainId": "43114",
+  "createdAt": 1735826000000,
+  "meta": {
+    "name": "Avalanche Token Transfers to gosuto_deployer",
+    "description": "Transfer AVAX (0.5928) native token and BAL (0.00000052) to gosuto_deployer",
+    "txBuilderVersion": "1.17.0",
+    "createdFromSafeAddress": "0x326A7778DB9B741Cb2acA0DE07b9402C7685dAc6",
+    "createdFromOwnerAddress": ""
+  },
+  "transactions": [
+    {
+      "to": "0x4BC8121278056BFCaC2BD14D455659224d6dDf48",
+      "value": "592800000000000000",
+      "data": null,
+      "contractMethod": null,
+      "contractInputsValues": null
+    },
+    {
+      "to": "0xE15bCB9E0EA69e6aB9FA080c4c4A5632896298C3",
+      "value": "0",
+      "data": null,
+      "contractMethod": {
+        "inputs": [
+          {
+            "name": "to",
+            "type": "address"
+          },
+          {
+            "name": "value",
+            "type": "uint256"
+          }
+        ],
+        "name": "transfer",
+        "payable": false
+      },
+      "contractInputsValues": {
+        "to": "0x4BC8121278056BFCaC2BD14D455659224d6dDf48",
+        "value": "520000000000"
+      }
+    }
+  ]
+}

--- a/MaxiOps/LM_Cleanup/ethereum_dust_transfers.json
+++ b/MaxiOps/LM_Cleanup/ethereum_dust_transfers.json
@@ -1,0 +1,90 @@
+{
+  "version": "1.0",
+  "chainId": "1",
+  "createdAt": 1735826000000,
+  "meta": {
+    "name": "Ethereum Token Transfers to gosuto_deployer",
+    "description": "Transfer ETH (0.073638815371443902), TUSD (30), aBAL (0.893950579082797267), and VITA (0.01050278) to gosuto_deployer",
+    "txBuilderVersion": "1.17.0",
+    "createdFromSafeAddress": "0xc38c5f97B34E175FFd35407fc91a937300E33860",
+    "createdFromOwnerAddress": ""
+  },
+  "transactions": [
+    {
+      "to": "0x4BC8121278056BFCaC2BD14D455659224d6dDf48",
+      "value": "73638815371443902",
+      "data": null,
+      "contractMethod": null,
+      "contractInputsValues": null
+    },
+    {
+      "to": "0x0000000000085d4780b73119b644ae5ecd22b376",
+      "value": "0",
+      "data": null,
+      "contractMethod": {
+        "inputs": [
+          {
+            "name": "to",
+            "type": "address"
+          },
+          {
+            "name": "value",
+            "type": "uint256"
+          }
+        ],
+        "name": "transfer",
+        "payable": false
+      },
+      "contractInputsValues": {
+        "to": "0x4BC8121278056BFCaC2BD14D455659224d6dDf48",
+        "value": "30000000000000000000"
+      }
+    },
+    {
+      "to": "0x272f97b7a56a387ae942350bbc7df5700f8a4576",
+      "value": "0",
+      "data": null,
+      "contractMethod": {
+        "inputs": [
+          {
+            "name": "to",
+            "type": "address"
+          },
+          {
+            "name": "value",
+            "type": "uint256"
+          }
+        ],
+        "name": "transfer",
+        "payable": false
+      },
+      "contractInputsValues": {
+        "to": "0x4BC8121278056BFCaC2BD14D455659224d6dDf48",
+        "value": "893950579082797267"
+      }
+    },
+    {
+      "to": "0x81f8f0bb1cb2a06649e51913a151f0e7ef6fa321",
+      "value": "0",
+      "data": null,
+      "contractMethod": {
+        "inputs": [
+          {
+            "name": "to",
+            "type": "address"
+          },
+          {
+            "name": "value",
+            "type": "uint256"
+          }
+        ],
+        "name": "transfer",
+        "payable": false
+      },
+      "contractInputsValues": {
+        "to": "0x4BC8121278056BFCaC2BD14D455659224d6dDf48",
+        "value": "10502780000000000"
+      }
+    }
+  ]
+}

--- a/MaxiOps/LM_Cleanup/gnosis_dust_transfers.json
+++ b/MaxiOps/LM_Cleanup/gnosis_dust_transfers.json
@@ -1,0 +1,37 @@
+{
+  "version": "1.0",
+  "chainId": "100",
+  "createdAt": 1735826000000,
+  "meta": {
+    "name": "Gnosis Token Transfers to gosuto_deployer",
+    "description": "Transfer BAL (0.001268461583997469) to gosuto_deployer",
+    "txBuilderVersion": "1.17.0",
+    "createdFromSafeAddress": "0x14969B55a675d13a1700F71A37511bc22D90155a",
+    "createdFromOwnerAddress": ""
+  },
+  "transactions": [
+    {
+      "to": "0x7eF541E2a22058048904fE5744f9c7E4C57AF717",
+      "value": "0",
+      "data": null,
+      "contractMethod": {
+        "inputs": [
+          {
+            "name": "to",
+            "type": "address"
+          },
+          {
+            "name": "value",
+            "type": "uint256"
+          }
+        ],
+        "name": "transfer",
+        "payable": false
+      },
+      "contractInputsValues": {
+        "to": "0x4BC8121278056BFCaC2BD14D455659224d6dDf48",
+        "value": "1268461583997469"
+      }
+    }
+  ]
+}

--- a/MaxiOps/LM_Cleanup/polygon_dust_transfers.json
+++ b/MaxiOps/LM_Cleanup/polygon_dust_transfers.json
@@ -1,0 +1,113 @@
+{
+  "version": "1.0",
+  "chainId": "137",
+  "createdAt": 1735826000000,
+  "meta": {
+    "name": "Polygon Token Transfers to gosuto_deployer",
+    "description": "Transfer Aave Polygon BAL (3.639977150090615761), LDO (1), TUSD (1), TEL (0.00161), and POL (0.00119364143100958) to gosuto_deployer",
+    "txBuilderVersion": "1.17.0",
+    "createdFromSafeAddress": "0xc38c5f97B34E175FFd35407fc91a937300E33860",
+    "createdFromOwnerAddress": ""
+  },
+  "transactions": [
+    {
+      "to": "0x8ffDf2DE812095b1D19CB146E4c004587C0A0692",
+      "value": "0",
+      "data": null,
+      "contractMethod": {
+        "inputs": [
+          {
+            "name": "to",
+            "type": "address"
+          },
+          {
+            "name": "value",
+            "type": "uint256"
+          }
+        ],
+        "name": "transfer",
+        "payable": false
+      },
+      "contractInputsValues": {
+        "to": "0x4BC8121278056BFCaC2BD14D455659224d6dDf48",
+        "value": "3639977150090615761"
+      }
+    },
+    {
+      "to": "0xC3C7d422809852031b44ab29EEC9F1EfF2A58756",
+      "value": "0",
+      "data": null,
+      "contractMethod": {
+        "inputs": [
+          {
+            "name": "to",
+            "type": "address"
+          },
+          {
+            "name": "value",
+            "type": "uint256"
+          }
+        ],
+        "name": "transfer",
+        "payable": false
+      },
+      "contractInputsValues": {
+        "to": "0x4BC8121278056BFCaC2BD14D455659224d6dDf48",
+        "value": "1000000000000000000"
+      }
+    },
+    {
+      "to": "0x2e1AD108fF1D8C782fcBbB89AAd783aC49586756",
+      "value": "0",
+      "data": null,
+      "contractMethod": {
+        "inputs": [
+          {
+            "name": "to",
+            "type": "address"
+          },
+          {
+            "name": "value",
+            "type": "uint256"
+          }
+        ],
+        "name": "transfer",
+        "payable": false
+      },
+      "contractInputsValues": {
+        "to": "0x4BC8121278056BFCaC2BD14D455659224d6dDf48",
+        "value": "1000000000000000000"
+      }
+    },
+    {
+      "to": "0xdF7837DE1F2Fa4631D716CF2502f8b230F1dcc32",
+      "value": "0",
+      "data": null,
+      "contractMethod": {
+        "inputs": [
+          {
+            "name": "to",
+            "type": "address"
+          },
+          {
+            "name": "value",
+            "type": "uint256"
+          }
+        ],
+        "name": "transfer",
+        "payable": false
+      },
+      "contractInputsValues": {
+        "to": "0x4BC8121278056BFCaC2BD14D455659224d6dDf48",
+        "value": "161"
+      }
+    },
+    {
+      "to": "0x4BC8121278056BFCaC2BD14D455659224d6dDf48",
+      "value": "1193641431009580",
+      "data": null,
+      "contractMethod": null,
+      "contractInputsValues": null
+    }
+  ]
+}


### PR DESCRIPTION
- Remove dust amounts from the LM multi-sigs on all networks and send to gosuto's deployer
- Everything in the [overview table](https://docs.google.com/spreadsheets/d/1rO0url2jglxhhMpmr36LJP6gtBcoS8HTNWJ2xxMIj9U/edit?gid=894654757#gid=894654757) (plus some more smaller dust), row 12 onwards