### PR TITLE
Manually Withdraw Mode and Fraxtal Protocol Fees

### DIFF
--- a/MaxiOps/ManualFeeSweeps/Fraxtal_withDrawFromFeeCollector_09_2025.json
+++ b/MaxiOps/ManualFeeSweeps/Fraxtal_withDrawFromFeeCollector_09_2025.json
@@ -1,0 +1,47 @@
+{
+  "version": "1.0",
+  "chainId": "252",
+  "createdAt": 1757074216000,
+  "meta": {
+    "name": "Transactions Batch",
+    "description": "Withdraw accumulated Fraxtal fees from Fee Collector to Xeonus' deployer for processing.",
+    "txBuilderVersion": "1.18.0",
+    "createdFromSafeAddress": "0x9ff471F9f98F42E5151C7855fD1b5aa906b1AF7e",
+    "createdFromOwnerAddress": "",
+    "checksum": ""
+  },
+  "transactions": [
+    {
+      "to": "0x85a80afee867aDf27B50BdB7b76DA70f1E853062",
+      "value": "0",
+      "data": null,
+      "contractMethod": {
+        "inputs": [
+          {
+            "internalType": "contract IERC20[]",
+            "name": "tokens",
+            "type": "address[]"
+          },
+          {
+            "internalType": "uint256[]",
+            "name": "amounts",
+            "type": "uint256[]"
+          },
+          {
+            "internalType": "address",
+            "name": "recipient",
+            "type": "address"
+          }
+        ],
+        "name": "withdrawCollectedFees",
+        "payable": false
+      },
+      "contractInputsValues": {
+        "tokens": "[0xA0b92B33BeafcE388Ce0092afDcd0cA77323Eb12,0x33251abeCb0364Df98a27A8D5d7b5CCddc774c42,0x1570315476480fa80cec1fff07a20c1df1adfd53]",
+        "amounts": "[570282567531983730631,1008161369349430842179,81473192543529746992]",
+        "recipient": "0x735fddb3e475e5f7a61ef674c72a7ede82d1f493"
+      }
+    }
+  ]
+}
+

--- a/MaxiOps/ManualFeeSweeps/Mode_withdrawFromFeeCollector_xeoDeployer_09_2025.json
+++ b/MaxiOps/ManualFeeSweeps/Mode_withdrawFromFeeCollector_xeoDeployer_09_2025.json
@@ -1,0 +1,46 @@
+{
+  "version": "1.0",
+  "chainId": "34443",
+  "createdAt": 1757074216000,
+  "meta": {
+    "name": "Transactions Batch",
+    "description": "Withdraw accumulated Fraxtal fees from Fee Collector to Xeonus' deployer for processing.",
+    "txBuilderVersion": "1.18.0",
+    "createdFromSafeAddress": "0x9ff471F9f98F42E5151C7855fD1b5aa906b1AF7e",
+    "createdFromOwnerAddress": "",
+    "checksum": ""
+  },
+  "transactions": [
+    {
+      "to": "0x85a80afee867aDf27B50BdB7b76DA70f1E853062",
+      "value": "0",
+      "data": null,
+      "contractMethod": {
+        "inputs": [
+          {
+            "internalType": "contract IERC20[]",
+            "name": "tokens",
+            "type": "address[]"
+          },
+          {
+            "internalType": "uint256[]",
+            "name": "amounts",
+            "type": "uint256[]"
+          },
+          {
+            "internalType": "address",
+            "name": "recipient",
+            "type": "address"
+          }
+        ],
+        "name": "withdrawCollectedFees",
+        "payable": false
+      },
+      "contractInputsValues": {
+        "tokens": "[0x1224d4e918E69189760888fd40EC1491c93CD59B,0x7c86a44778c52a0AAD17860924b53bf3f35Dc932]",
+        "amounts": "[7717120117981134,96911777575803]",
+        "recipient": "0x735fddb3e475e5f7a61ef674c72a7ede82d1f493"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
- Withdraw BPTs from Fee collector contract to Xeo's deployer
- Xeo will then withdraw BPTs to tokens, trade / bridge to mainnet for USDC and send to the fee allocator safe

## Fraxtal
- Sweep positions >$100_ sfrxETH/sfrxUSD, sDAI/sUSDe/sfrxUSD
- [Status](https://debank.com/profile/0xce88686553686da562ce7cea497ce749da109f9f?chain=frax)

MODE:
- sweep positions >$100: WETH/MODE, m-BTC/uniBTC
- [Status](https://debank.com/profile/0xce88686553686da562ce7cea497ce749da109f9f?chain=mode)

## Accounting
Trades will be tracked in [this sheet](https://docs.google.com/spreadsheets/d/19yWH9jns_pVIkXp6uM_3y6ovdNYTVgn5rOKBb7uz93M/edit?gid=0#gid=0)