### PR TITLE
Aura Locker: Manual relock

### DIFF
--- a/MaxiOps/AuraLocker/Manual_relock_Oct_2025.json
+++ b/MaxiOps/AuraLocker/Manual_relock_Oct_2025.json
@@ -1,0 +1,33 @@
+{
+  "version": "1.0",
+  "chainId": "1",
+  "createdAt": 1759754739,
+  "meta": {
+    "name": "Relock vlAura",
+    "description": "",
+    "txBuilderVersion": "1.16.3",
+    "createdFromSafeAddress": "0x9a5BDF08a6969A4bDb7724beE3c6d8964BDc0B28",
+    "createdFromOwnerAddress": ""
+  },
+  "transactions": [
+    {
+      "to": "0x3Fa73f1E5d8A792C80F426fc8F84FBF7Ce9bBCAC",
+      "value": "0",
+      "data": null,
+      "contractMethod": {
+        "inputs": [
+          {
+            "name": "_relock",
+            "type": "bool",
+            "internalType": "bool"
+          }
+        ],
+        "name": "processExpiredLocks",
+        "payable": false
+      },
+      "contractInputsValues": {
+        "_relock": "true"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
- manually relock 2mln vlAURA expiring this Thursday Oct 9th 2025 as there is a potential risk with the current locker module to relock after the Aura voting power snapshot
- This is a one-time relock. Goal is to install the revised locker module that has relock logic in place for "expiring locks"
- To be on the safe side this payload needs to be EXECUTED BEFORE unix timestamp 1759960799 (=Wed Oct 08 2025 21:59:59 GMT+0000)