### PR TITLE
properly calc hh rewards for aura locker

### DIFF
--- a/tools/python/aura_locker_harvesting/harvest_bribes.py
+++ b/tools/python/aura_locker_harvesting/harvest_bribes.py
@@ -237,15 +237,21 @@ def claim_hidden_hand_bribes(
             remaining_amount = total_amount - claimed_amount
 
             if remaining_amount <= 0:
-                print(f"Skipping {claim['token']} - fully claimed (claimed: {claimed_amount}, total: {total_amount})")
+                print(
+                    f"Skipping {claim['token']} - fully claimed (claimed: {claimed_amount}, total: {total_amount})"
+                )
                 continue
 
             claim["amount"] = str(remaining_amount)
 
             if claimed_amount > 0:
-                print(f"Partially claimed {claim['token']} - claiming remaining {remaining_amount} (already claimed: {claimed_amount})")
+                print(
+                    f"Partially claimed {claim['token']} - claiming remaining {remaining_amount} (already claimed: {claimed_amount})"
+                )
             else:
-                print(f"Claiming HH - token: {claim['token']}, amount: {remaining_amount}")
+                print(
+                    f"Claiming HH - token: {claim['token']}, amount: {remaining_amount}"
+                )
 
             valid_claims.append(claim)
 


### PR DESCRIPTION
hiddenhand tracks cumulative total for rewards. so to claim a token we've claimed in the past, we need to subtract the amount we've claimed previously from the cumulative amount. this is unlike paladin where it is binary (claimed/not claimed)

resolves issue in [#2498](https://github.com/BalancerMaxis/multisig-ops/pull/2498#issuecomment-3458102674) where the rpl/usdc rewards were not being claimed because it used same logic as paladin (claimed before = nothing left to claim)

sim from running new changes locally: https://dashboard.tenderly.co/public/safe/safe-apps/simulator/1eea217d-1e4f-41c9-9edc-5a2c1ee7f6ba (now includes usdc/rpl rewards)