### PR TITLE
add `auto_include` flag to rETH/waEthWETH alliance pool

### DIFF
--- a/config/alliance_fee_share.json
+++ b/config/alliance_fee_share.json
@@ -12,7 +12,8 @@
           "network": "mainnet",
           "partner": "Rocket Pool",
           "eligibility_date": "2025-11-13",
-          "active": true
+          "active": true,
+          "auto_include": true
         },
         {
           "pool_id": "0x5418a64e0cdb20548ACB394f5D00a089BAf02161",


### PR DESCRIPTION
solves remaining issue for https://github.com/orgs/maxyz-xyz/projects/2/views/1?filterQuery=jal&pane=issue&itemId=145483293&issue=BalancerMaxis%7Cprotocol_fee_allocator_v2%7C265 so that the migrated rocket pool unconditionally gets an alliance fee share