### PR TITLE
Update StableSurge Hook Parameters for JUSD / sJUSD / USDC on Ethereum

### DIFF
--- a/MaxiOps/PoolParameterChanges/PoolStableSurgeParams/Mainnet/stable-surge-params-0xb20fa48d028b5ba6de33e09c72643c1fe92f8fcd-2026-02-13_1655.json
+++ b/MaxiOps/PoolParameterChanges/PoolStableSurgeParams/Mainnet/stable-surge-params-0xb20fa48d028b5ba6de33e09c72643c1fe92f8fcd-2026-02-13_1655.json
@@ -1,1 +1,54 @@
-{"version":"1.0","chainId":"1","createdAt":1770998141136,"meta":{"name":"Transactions Batch","description":"Set surge threshold to 40% and max surge fee to 9% for pool 0xb20fa48d028b5ba6de33e09c72643c1fe92f8fcd","createdFromSafeAddress":"0x9ff471F9f98F42E5151C7855fD1b5aa906b1AF7e"},"transactions":[{"to":"0xbdbadc891bb95dee80ebc491699228ef0f7d6ff1","value":"0","data":null,"contractMethod":{"inputs":[{"internalType":"address","name":"pool","type":"address"},{"internalType":"uint256","name":"newMaxSurgeSurgeFeePercentage","type":"uint256"}],"name":"setMaxSurgeFeePercentage","payable":false},"contractInputsValues":{"pool":"0xb20fa48d028b5ba6de33e09c72643c1fe92f8fcd","newMaxSurgeSurgeFeePercentage":"90000000000000000"}},{"to":"0xbdbadc891bb95dee80ebc491699228ef0f7d6ff1","value":"0","data":null,"contractMethod":{"inputs":[{"internalType":"address","name":"pool","type":"address"},{"internalType":"uint256","name":"newSurgeThresholdPercentage","type":"uint256"}],"name":"setSurgeThresholdPercentage","payable":false},"contractInputsValues":{"pool":"0xb20fa48d028b5ba6de33e09c72643c1fe92f8fcd","newSurgeThresholdPercentage":"400000000000000000"}}]}
+{
+  "version": "1.0",
+  "chainId": "1",
+  "createdAt": 1770998141136,
+  "meta": {
+    "name": "Transactions Batch",
+    "description": "Set surge threshold to 40% and max surge fee to 9% for pool 0xb20fa48d028b5ba6de33e09c72643c1fe92f8fcd",
+    "createdFromSafeAddress": "0x9ff471F9f98F42E5151C7855fD1b5aa906b1AF7e"
+  },
+  "transactions": [
+    {
+      "to": "0xbdbadc891bb95dee80ebc491699228ef0f7d6ff1",
+      "value": "0",
+      "data": null,
+      "contractMethod": {
+        "inputs": [
+          { "internalType": "address", "name": "pool", "type": "address" },
+          {
+            "internalType": "uint256",
+            "name": "newMaxSurgeSurgeFeePercentage",
+            "type": "uint256"
+          }
+        ],
+        "name": "setMaxSurgeFeePercentage",
+        "payable": false
+      },
+      "contractInputsValues": {
+        "pool": "0xb20fa48d028b5ba6de33e09c72643c1fe92f8fcd",
+        "newMaxSurgeSurgeFeePercentage": "90000000000000000"
+      }
+    },
+    {
+      "to": "0xbdbadc891bb95dee80ebc491699228ef0f7d6ff1",
+      "value": "0",
+      "data": null,
+      "contractMethod": {
+        "inputs": [
+          { "internalType": "address", "name": "pool", "type": "address" },
+          {
+            "internalType": "uint256",
+            "name": "newSurgeThresholdPercentage",
+            "type": "uint256"
+          }
+        ],
+        "name": "setSurgeThresholdPercentage",
+        "payable": false
+      },
+      "contractInputsValues": {
+        "pool": "0xb20fa48d028b5ba6de33e09c72643c1fe92f8fcd",
+        "newSurgeThresholdPercentage": "400000000000000000"
+      }
+    }
+  ]
+}

--- a/MaxiOps/PoolParameterChanges/PoolStableSurgeParams/Mainnet/stable-surge-params-0xb20fa48d028b5ba6de33e09c72643c1fe92f8fcd-2026-02-13_1655.report.txt
+++ b/MaxiOps/PoolParameterChanges/PoolStableSurgeParams/Mainnet/stable-surge-params-0xb20fa48d028b5ba6de33e09c72643c1fe92f8fcd-2026-02-13_1655.report.txt
@@ -1,0 +1,28 @@
+FILENAME: `MaxiOps/PoolParameterChanges/PoolStableSurgeParams/Mainnet/stable-surge-params-0xb20fa48d028b5ba6de33e09c72643c1fe92f8fcd-2026-02-13_1655.json`
+MULTISIG: `multisigs/omni (mainnet:0x9ff471F9f98F42E5151C7855fD1b5aa906b1AF7e)`
+COMMIT: `9c5aaf8488b2d8a86d0b7f992550fa346aced9d5`
+CHAIN(S): `mainnet`
+TENDERLY: [`🟩 SUCCESS`](https://www.tdly.co/shared/simulation/a15d3cba-22e4-4b1c-ae6e-32bb8548189d)
+
+```
++-----------------------------+-----------------------------------------------------------------------------------------------+-------+--------------------------------------------------------+------------+----------+
+| fx_name                     | to                                                                                            | value | inputs                                                 | bip_number | tx_index |
++-----------------------------+-----------------------------------------------------------------------------------------------+-------+--------------------------------------------------------+------------+----------+
+| setMaxSurgeFeePercentage    | 0xbdbadc891bb95dee80ebc491699228ef0f7d6ff1 (20250403-v3-stable-surge-hook-v2/StableSurgeHook) | 0     | {                                                      | N/A        |   N/A    |
+|                             |                                                                                               |       |   "pool": [                                            |            |          |
+|                             |                                                                                               |       |     "0xb20fa48d028b5ba6de33e09c72643c1fe92f8fcd (N/A)" |            |          |
+|                             |                                                                                               |       |   ],                                                   |            |          |
+|                             |                                                                                               |       |   "newMaxSurgeSurgeFeePercentage": [                   |            |          |
+|                             |                                                                                               |       |     "90000000000000000"                                |            |          |
+|                             |                                                                                               |       |   ]                                                    |            |          |
+|                             |                                                                                               |       | }                                                      |            |          |
+| setSurgeThresholdPercentage | 0xbdbadc891bb95dee80ebc491699228ef0f7d6ff1 (20250403-v3-stable-surge-hook-v2/StableSurgeHook) | 0     | {                                                      | N/A        |   N/A    |
+|                             |                                                                                               |       |   "pool": [                                            |            |          |
+|                             |                                                                                               |       |     "0xb20fa48d028b5ba6de33e09c72643c1fe92f8fcd (N/A)" |            |          |
+|                             |                                                                                               |       |   ],                                                   |            |          |
+|                             |                                                                                               |       |   "newSurgeThresholdPercentage": [                     |            |          |
+|                             |                                                                                               |       |     "400000000000000000"                               |            |          |
+|                             |                                                                                               |       |   ]                                                    |            |          |
+|                             |                                                                                               |       | }                                                      |            |          |
++-----------------------------+-----------------------------------------------------------------------------------------------+-------+--------------------------------------------------------+------------+----------+
+```


### PR DESCRIPTION
This PR decreases the max surge fee from 95.00% to 9.00% and increases the surge threshold from 30.00% to 40.00% for the Aegis JUSD / sJUSD / USDC pool (0xb20fa4) on Ethereum.