### PR TITLE
Update StableSurge Hook Parameters for wnAUSD / wnUSDC / wnUSDT0 on Monad

### DIFF
--- a/MaxiOps/PoolParameterChanges/PoolStableSurgeParams/Monad/stable-surge-params-0x2daa146dfb7eaef0038f9f15b2ec1e4de003f72b-2026-02-16_2049.json
+++ b/MaxiOps/PoolParameterChanges/PoolStableSurgeParams/Monad/stable-surge-params-0x2daa146dfb7eaef0038f9f15b2ec1e4de003f72b-2026-02-16_2049.json
@@ -1,1 +1,54 @@
-{"version":"1.0","chainId":"143","createdAt":1771271384712,"meta":{"name":"Transactions Batch","description":"Set surge threshold to 45% and max surge fee to 5% for pool 0x2daa146dfb7eaef0038f9f15b2ec1e4de003f72b","createdFromSafeAddress":"0x9ff471F9f98F42E5151C7855fD1b5aa906b1AF7e"},"transactions":[{"to":"0x6817149cb753bf529565b4d023d7507ed2ff4bc0","value":"0","data":null,"contractMethod":{"inputs":[{"internalType":"address","name":"pool","type":"address"},{"internalType":"uint256","name":"newMaxSurgeSurgeFeePercentage","type":"uint256"}],"name":"setMaxSurgeFeePercentage","payable":false},"contractInputsValues":{"pool":"0x2daa146dfb7eaef0038f9f15b2ec1e4de003f72b","newMaxSurgeSurgeFeePercentage":"50000000000000000"}},{"to":"0x6817149cb753bf529565b4d023d7507ed2ff4bc0","value":"0","data":null,"contractMethod":{"inputs":[{"internalType":"address","name":"pool","type":"address"},{"internalType":"uint256","name":"newSurgeThresholdPercentage","type":"uint256"}],"name":"setSurgeThresholdPercentage","payable":false},"contractInputsValues":{"pool":"0x2daa146dfb7eaef0038f9f15b2ec1e4de003f72b","newSurgeThresholdPercentage":"450000000000000000"}}]}
+{
+  "version": "1.0",
+  "chainId": "143",
+  "createdAt": 1771271384712,
+  "meta": {
+    "name": "Transactions Batch",
+    "description": "Set surge threshold to 45% and max surge fee to 5% for pool 0x2daa146dfb7eaef0038f9f15b2ec1e4de003f72b",
+    "createdFromSafeAddress": "0x9ff471F9f98F42E5151C7855fD1b5aa906b1AF7e"
+  },
+  "transactions": [
+    {
+      "to": "0x6817149cb753bf529565b4d023d7507ed2ff4bc0",
+      "value": "0",
+      "data": null,
+      "contractMethod": {
+        "inputs": [
+          { "internalType": "address", "name": "pool", "type": "address" },
+          {
+            "internalType": "uint256",
+            "name": "newMaxSurgeSurgeFeePercentage",
+            "type": "uint256"
+          }
+        ],
+        "name": "setMaxSurgeFeePercentage",
+        "payable": false
+      },
+      "contractInputsValues": {
+        "pool": "0x2daa146dfb7eaef0038f9f15b2ec1e4de003f72b",
+        "newMaxSurgeSurgeFeePercentage": "50000000000000000"
+      }
+    },
+    {
+      "to": "0x6817149cb753bf529565b4d023d7507ed2ff4bc0",
+      "value": "0",
+      "data": null,
+      "contractMethod": {
+        "inputs": [
+          { "internalType": "address", "name": "pool", "type": "address" },
+          {
+            "internalType": "uint256",
+            "name": "newSurgeThresholdPercentage",
+            "type": "uint256"
+          }
+        ],
+        "name": "setSurgeThresholdPercentage",
+        "payable": false
+      },
+      "contractInputsValues": {
+        "pool": "0x2daa146dfb7eaef0038f9f15b2ec1e4de003f72b",
+        "newSurgeThresholdPercentage": "450000000000000000"
+      }
+    }
+  ]
+}

--- a/MaxiOps/PoolParameterChanges/PoolStableSurgeParams/Monad/stable-surge-params-0x2daa146dfb7eaef0038f9f15b2ec1e4de003f72b-2026-02-16_2049.report.txt
+++ b/MaxiOps/PoolParameterChanges/PoolStableSurgeParams/Monad/stable-surge-params-0x2daa146dfb7eaef0038f9f15b2ec1e4de003f72b-2026-02-16_2049.report.txt
@@ -1,0 +1,28 @@
+FILENAME: `MaxiOps/PoolParameterChanges/PoolStableSurgeParams/Monad/stable-surge-params-0x2daa146dfb7eaef0038f9f15b2ec1e4de003f72b-2026-02-16_2049.json`
+MULTISIG: `multisigs/omni (monad:0x9ff471F9f98F42E5151C7855fD1b5aa906b1AF7e)`
+COMMIT: `df21e49c3c7c88db34c0a58758c8f0a97955adb4`
+CHAIN(S): `monad`
+TENDERLY: [`🟩 SUCCESS`](https://www.tdly.co/shared/simulation/284231fb-f9ee-486a-b41f-7b8df9c20f18)
+
+```
++-----------------------------+-----------------------------------------------------------------------------------------------+-------+--------------------------------------------------------+------------+----------+
+| fx_name                     | to                                                                                            | value | inputs                                                 | bip_number | tx_index |
++-----------------------------+-----------------------------------------------------------------------------------------------+-------+--------------------------------------------------------+------------+----------+
+| setMaxSurgeFeePercentage    | 0x6817149cb753bf529565b4d023d7507ed2ff4bc0 (20250403-v3-stable-surge-hook-v2/StableSurgeHook) | 0     | {                                                      | N/A        |   N/A    |
+|                             |                                                                                               |       |   "pool": [                                            |            |          |
+|                             |                                                                                               |       |     "0x2daa146dfb7eaef0038f9f15b2ec1e4de003f72b (N/A)" |            |          |
+|                             |                                                                                               |       |   ],                                                   |            |          |
+|                             |                                                                                               |       |   "newMaxSurgeSurgeFeePercentage": [                   |            |          |
+|                             |                                                                                               |       |     "50000000000000000"                                |            |          |
+|                             |                                                                                               |       |   ]                                                    |            |          |
+|                             |                                                                                               |       | }                                                      |            |          |
+| setSurgeThresholdPercentage | 0x6817149cb753bf529565b4d023d7507ed2ff4bc0 (20250403-v3-stable-surge-hook-v2/StableSurgeHook) | 0     | {                                                      | N/A        |   N/A    |
+|                             |                                                                                               |       |   "pool": [                                            |            |          |
+|                             |                                                                                               |       |     "0x2daa146dfb7eaef0038f9f15b2ec1e4de003f72b (N/A)" |            |          |
+|                             |                                                                                               |       |   ],                                                   |            |          |
+|                             |                                                                                               |       |   "newSurgeThresholdPercentage": [                     |            |          |
+|                             |                                                                                               |       |     "450000000000000000"                               |            |          |
+|                             |                                                                                               |       |   ]                                                    |            |          |
+|                             |                                                                                               |       | }                                                      |            |          |
++-----------------------------+-----------------------------------------------------------------------------------------------+-------+--------------------------------------------------------+------------+----------+
+```

--- a/MaxiOps/vlaura_voting/2026/W7/output/payload.json
+++ b/MaxiOps/vlaura_voting/2026/W7/output/payload.json
@@ -1,52 +1,52 @@
 {
-    "domain": {
-        "name": "snapshot",
-        "version": "0.1.4"
-    },
-    "types": {
-        "Vote": [
-            {
-                "name": "from",
-                "type": "address"
-            },
-            {
-                "name": "space",
-                "type": "string"
-            },
-            {
-                "name": "timestamp",
-                "type": "uint64"
-            },
-            {
-                "name": "proposal",
-                "type": "bytes32"
-            },
-            {
-                "name": "choice",
-                "type": "string"
-            },
-            {
-                "name": "reason",
-                "type": "string"
-            },
-            {
-                "name": "app",
-                "type": "string"
-            },
-            {
-                "name": "metadata",
-                "type": "string"
-            }
-        ]
-    },
-    "message": {
-        "space": "gauges.aurafinance.eth",
-        "proposal": "0x41ce79eee2c532f7b889ff65db57b481d49f1e5c19e29f9a16092fc067872513",
-        "choice": "{\"32\":5.0,\"138\":5.0,\"132\":5.0,\"80\":3.0,\"28\":30.0,\"27\":2.0,\"85\":5.0,\"18\":2.0,\"129\":3.0,\"48\":20.0,\"49\":20.0}",
-        "app": "snapshot",
-        "reason": "On behalf of Balancer DAO",
-        "metadata": "{}",
-        "from": "0xBeF27037bC6311b96635E5e9Af3A73EBF6Ca8878",
-        "timestamp": 1770985969
-    }
+  "domain": {
+    "name": "snapshot",
+    "version": "0.1.4"
+  },
+  "types": {
+    "Vote": [
+      {
+        "name": "from",
+        "type": "address"
+      },
+      {
+        "name": "space",
+        "type": "string"
+      },
+      {
+        "name": "timestamp",
+        "type": "uint64"
+      },
+      {
+        "name": "proposal",
+        "type": "bytes32"
+      },
+      {
+        "name": "choice",
+        "type": "string"
+      },
+      {
+        "name": "reason",
+        "type": "string"
+      },
+      {
+        "name": "app",
+        "type": "string"
+      },
+      {
+        "name": "metadata",
+        "type": "string"
+      }
+    ]
+  },
+  "message": {
+    "space": "gauges.aurafinance.eth",
+    "proposal": "0x41ce79eee2c532f7b889ff65db57b481d49f1e5c19e29f9a16092fc067872513",
+    "choice": "{\"32\":5.0,\"138\":5.0,\"132\":5.0,\"80\":3.0,\"28\":30.0,\"27\":2.0,\"85\":5.0,\"18\":2.0,\"129\":3.0,\"48\":20.0,\"49\":20.0}",
+    "app": "snapshot",
+    "reason": "On behalf of Balancer DAO",
+    "metadata": "{}",
+    "from": "0xBeF27037bC6311b96635E5e9Af3A73EBF6Ca8878",
+    "timestamp": 1770985969
+  }
 }


### PR DESCRIPTION
This PR decreases the max surge fee from 95.00% to 5.00% and increases the surge threshold from 30.00% to 45.00% for wnAUSD / wnUSDC / wnUSDT0 (0x2daa14) on Monad.

Parameters were set in coordination with Zekraken.