### PR TITLE
Update StableSurge Hook Parameters for sJUSD / JUSD / kpk_USDC_Prime on Ethereum

### DIFF
--- a/MaxiOps/PoolParameterChanges/PoolStableSurgeParams/Mainnet/stable-surge-params-0x083f0c045e79774b58d9030e6c98b2d1c7ad8b73-2026-02-27_1837.json
+++ b/MaxiOps/PoolParameterChanges/PoolStableSurgeParams/Mainnet/stable-surge-params-0x083f0c045e79774b58d9030e6c98b2d1c7ad8b73-2026-02-27_1837.json
@@ -1,1 +1,54 @@
-{"version":"1.0","chainId":"1","createdAt":1772213823955,"meta":{"name":"Transactions Batch","description":"Set surge threshold to 40% and max surge fee to 9% for pool 0x083f0c045e79774b58d9030e6c98b2d1c7ad8b73","createdFromSafeAddress":"0x9ff471F9f98F42E5151C7855fD1b5aa906b1AF7e"},"transactions":[{"to":"0xbdbadc891bb95dee80ebc491699228ef0f7d6ff1","value":"0","data":null,"contractMethod":{"inputs":[{"internalType":"address","name":"pool","type":"address"},{"internalType":"uint256","name":"newMaxSurgeSurgeFeePercentage","type":"uint256"}],"name":"setMaxSurgeFeePercentage","payable":false},"contractInputsValues":{"pool":"0x083f0c045e79774b58d9030e6c98b2d1c7ad8b73","newMaxSurgeSurgeFeePercentage":"90000000000000000"}},{"to":"0xbdbadc891bb95dee80ebc491699228ef0f7d6ff1","value":"0","data":null,"contractMethod":{"inputs":[{"internalType":"address","name":"pool","type":"address"},{"internalType":"uint256","name":"newSurgeThresholdPercentage","type":"uint256"}],"name":"setSurgeThresholdPercentage","payable":false},"contractInputsValues":{"pool":"0x083f0c045e79774b58d9030e6c98b2d1c7ad8b73","newSurgeThresholdPercentage":"400000000000000000"}}]}
+{
+  "version": "1.0",
+  "chainId": "1",
+  "createdAt": 1772213823955,
+  "meta": {
+    "name": "Transactions Batch",
+    "description": "Set surge threshold to 40% and max surge fee to 9% for pool 0x083f0c045e79774b58d9030e6c98b2d1c7ad8b73",
+    "createdFromSafeAddress": "0x9ff471F9f98F42E5151C7855fD1b5aa906b1AF7e"
+  },
+  "transactions": [
+    {
+      "to": "0xbdbadc891bb95dee80ebc491699228ef0f7d6ff1",
+      "value": "0",
+      "data": null,
+      "contractMethod": {
+        "inputs": [
+          { "internalType": "address", "name": "pool", "type": "address" },
+          {
+            "internalType": "uint256",
+            "name": "newMaxSurgeSurgeFeePercentage",
+            "type": "uint256"
+          }
+        ],
+        "name": "setMaxSurgeFeePercentage",
+        "payable": false
+      },
+      "contractInputsValues": {
+        "pool": "0x083f0c045e79774b58d9030e6c98b2d1c7ad8b73",
+        "newMaxSurgeSurgeFeePercentage": "90000000000000000"
+      }
+    },
+    {
+      "to": "0xbdbadc891bb95dee80ebc491699228ef0f7d6ff1",
+      "value": "0",
+      "data": null,
+      "contractMethod": {
+        "inputs": [
+          { "internalType": "address", "name": "pool", "type": "address" },
+          {
+            "internalType": "uint256",
+            "name": "newSurgeThresholdPercentage",
+            "type": "uint256"
+          }
+        ],
+        "name": "setSurgeThresholdPercentage",
+        "payable": false
+      },
+      "contractInputsValues": {
+        "pool": "0x083f0c045e79774b58d9030e6c98b2d1c7ad8b73",
+        "newSurgeThresholdPercentage": "400000000000000000"
+      }
+    }
+  ]
+}

--- a/MaxiOps/PoolParameterChanges/PoolStableSurgeParams/Mainnet/stable-surge-params-0x083f0c045e79774b58d9030e6c98b2d1c7ad8b73-2026-02-27_1837.report.txt
+++ b/MaxiOps/PoolParameterChanges/PoolStableSurgeParams/Mainnet/stable-surge-params-0x083f0c045e79774b58d9030e6c98b2d1c7ad8b73-2026-02-27_1837.report.txt
@@ -1,0 +1,28 @@
+FILENAME: `MaxiOps/PoolParameterChanges/PoolStableSurgeParams/Mainnet/stable-surge-params-0x083f0c045e79774b58d9030e6c98b2d1c7ad8b73-2026-02-27_1837.json`
+MULTISIG: `multisigs/omni (mainnet:0x9ff471F9f98F42E5151C7855fD1b5aa906b1AF7e)`
+COMMIT: `50185d6d3540f17551747bf162db84239531bdbc`
+CHAIN(S): `mainnet`
+TENDERLY: [`🟩 SUCCESS`](https://www.tdly.co/shared/simulation/114a6819-958c-4638-b675-fb847b4d49d0)
+
+```
++-----------------------------+-----------------------------------------------------------------------------------------------+-------+--------------------------------------------------------+------------+----------+
+| fx_name                     | to                                                                                            | value | inputs                                                 | bip_number | tx_index |
++-----------------------------+-----------------------------------------------------------------------------------------------+-------+--------------------------------------------------------+------------+----------+
+| setMaxSurgeFeePercentage    | 0xbdbadc891bb95dee80ebc491699228ef0f7d6ff1 (20250403-v3-stable-surge-hook-v2/StableSurgeHook) | 0     | {                                                      | N/A        |   N/A    |
+|                             |                                                                                               |       |   "pool": [                                            |            |          |
+|                             |                                                                                               |       |     "0x083f0c045e79774b58d9030e6c98b2d1c7ad8b73 (N/A)" |            |          |
+|                             |                                                                                               |       |   ],                                                   |            |          |
+|                             |                                                                                               |       |   "newMaxSurgeSurgeFeePercentage": [                   |            |          |
+|                             |                                                                                               |       |     "90000000000000000"                                |            |          |
+|                             |                                                                                               |       |   ]                                                    |            |          |
+|                             |                                                                                               |       | }                                                      |            |          |
+| setSurgeThresholdPercentage | 0xbdbadc891bb95dee80ebc491699228ef0f7d6ff1 (20250403-v3-stable-surge-hook-v2/StableSurgeHook) | 0     | {                                                      | N/A        |   N/A    |
+|                             |                                                                                               |       |   "pool": [                                            |            |          |
+|                             |                                                                                               |       |     "0x083f0c045e79774b58d9030e6c98b2d1c7ad8b73 (N/A)" |            |          |
+|                             |                                                                                               |       |   ],                                                   |            |          |
+|                             |                                                                                               |       |   "newSurgeThresholdPercentage": [                     |            |          |
+|                             |                                                                                               |       |     "400000000000000000"                               |            |          |
+|                             |                                                                                               |       |   ]                                                    |            |          |
+|                             |                                                                                               |       | }                                                      |            |          |
++-----------------------------+-----------------------------------------------------------------------------------------------+-------+--------------------------------------------------------+------------+----------+
+```


### PR DESCRIPTION
This PR decreases the max surge fee from 95.00% to 9.00% and increases the surge threshold from 30.00% to 40.00% for the Aegis sJUSD / JUSD / kpk_USDC_Prime (0x083f0c) pool on Ethereum.