### PR TITLE
feat: redo wpol campaign

### DIFF
--- a/BIPs/2026-W18/BIP-892-137_redo_wpol_campaign.json
+++ b/BIPs/2026-W18/BIP-892-137_redo_wpol_campaign.json
@@ -1,0 +1,141 @@
+{
+  "version": "1.0",
+  "chainId": "137",
+  "meta": {
+    "name": "Redo WPOL Campaign - BIP-892",
+    "txBuilderVersion": "1.16.3",
+    "createdFromSafeAddress": "0xeE071f4B516F69a1603dA393CdE8e76C40E5Be85"
+  },
+  "transactions": [
+    {
+      "to": "0x0d500B1d8E8eF31E21C99d1Db9A6444d3ADf1270",
+      "value": "0",
+      "data": null,
+      "contractMethod": {
+        "inputs": [
+          {
+            "internalType": "address",
+            "name": "spender",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "amount",
+            "type": "uint256"
+          }
+        ],
+        "name": "approve",
+        "payable": false
+      },
+      "contractInputsValues": {
+        "spender": "0x467665D4ae90e7A99c9C9AF785791058426d6eA0",
+        "amount": "5927159439709870321853252"
+      }
+    },
+    {
+      "to": "0x467665D4ae90e7A99c9C9AF785791058426d6eA0",
+      "value": "0",
+      "data": null,
+      "contractMethod": {
+        "inputs": [
+          {
+            "internalType": "uint256",
+            "name": "amount",
+            "type": "uint256"
+          }
+        ],
+        "name": "mint",
+        "payable": false
+      },
+      "contractInputsValues": {
+        "amount": "5927159439709870321853251"
+      }
+    },
+    {
+      "to": "0x467665D4ae90e7A99c9C9AF785791058426d6eA0",
+      "value": "0",
+      "data": null,
+      "contractMethod": {
+        "inputs": [
+          {
+            "internalType": "address",
+            "name": "spender",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "amount",
+            "type": "uint256"
+          }
+        ],
+        "name": "approve",
+        "payable": false
+      },
+      "contractInputsValues": {
+        "spender": "0x8BB4C975Ff3c250e0ceEA271728547f3802B36Fd",
+        "amount": "5927159439709870321853252"
+      }
+    },
+    {
+      "to": "0x8BB4C975Ff3c250e0ceEA271728547f3802B36Fd",
+      "value": "0",
+      "data": null,
+      "contractMethod": {
+        "inputs": [
+          {
+            "components": [
+              {
+                "internalType": "bytes32",
+                "name": "campaignId",
+                "type": "bytes32"
+              },
+              {
+                "internalType": "address",
+                "name": "creator",
+                "type": "address"
+              },
+              {
+                "internalType": "address",
+                "name": "rewardToken",
+                "type": "address"
+              },
+              {
+                "internalType": "uint256",
+                "name": "amount",
+                "type": "uint256"
+              },
+              {
+                "internalType": "uint32",
+                "name": "campaignType",
+                "type": "uint32"
+              },
+              {
+                "internalType": "uint32",
+                "name": "startTimestamp",
+                "type": "uint32"
+              },
+              {
+                "internalType": "uint32",
+                "name": "duration",
+                "type": "uint32"
+              },
+              {
+                "internalType": "bytes",
+                "name": "campaignData",
+                "type": "bytes"
+              }
+            ],
+            "internalType": "struct EngineCampaign",
+            "name": "newCampaign",
+            "type": "tuple"
+          }
+        ],
+        "name": "createCampaign",
+        "payable": false
+      },
+      "contractInputsValues": {
+        "newCampaign": "[\"0x0000000000000000000000000000000000000000000000000000000000000000\",\"0x0000000000000000000000000000000000000000\",\"0x467665D4ae90e7A99c9C9AF785791058426d6eA0\",\"5927159439709870321853251\",4,1775817206,3600,\"0x84716bf19df452c6a4d553c042ca70220db49f4d16ef4a3b5d5865b356d68063\"]"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
recovered amount of wpol of 1454128 was falsely attributed to one pool (0xcd78a20c597e367a4e478a2411ceb790604d7c8f000000000000000000000c22)

this should have been 1249510, with 196228wpol to x951d84e358dd8ad6b3ae6220981bcfc4baf95c84000000000000000000000d62 and 9977wpol to 0x8159462d255c1d24915cb51ec361f700174cd99400000000000000000000075d

this payload recreates the now 'cancelled' old one, but with correct numbers