### PR TITLE
fix: purge gh actions creds

### DIFF
--- a/.github/workflows/auto_upload_payloads.yaml
+++ b/.github/workflows/auto_upload_payloads.yaml
@@ -31,6 +31,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Create archive commit token
         id: archive-token


### PR DESCRIPTION
quick fix for not being able to write logs to payload archive