### PR TITLE
ci: brick already disabled workflows

### DIFF
--- a/.github/workflows/poke_injectors.yaml
+++ b/.github/workflows/poke_injectors.yaml
@@ -1,9 +1,7 @@
 name: Poke Onchain Rewards Injectors
 
-on:
-  workflow_dispatch:
-  schedule:
-    - cron: "0/5 * * * *"
+# Intentionally bricked. Restore the trigger block to re-enable this workflow.
+on: {}
 env:
   KEYWORDS: ${{ secrets.KEEPER_PRIVATE_WORDS }}
   DRPC_KEY: ${{ secrets.DRPC_KEY }}

--- a/.github/workflows/post_aura_gauge_votes.yaml
+++ b/.github/workflows/post_aura_gauge_votes.yaml
@@ -1,17 +1,7 @@
 name: Post vlAURA snapshot votes to voter multisig and send to the vote relayer
 
-on:
-  push:
-    branches:
-      - main
-    paths:
-      - "MaxiOps/vlaura_voting/**/input/*.csv"
-  workflow_dispatch:
-    inputs:
-      week-string:
-        description: "Week string in YYYY-W## format"
-        required: true
-        type: string
+# Intentionally bricked. Restore the trigger block to re-enable this workflow.
+on: {}
 
 jobs:
   post_aura_gauge_votes:

--- a/.github/workflows/review_aura_gauge_votes.yaml
+++ b/.github/workflows/review_aura_gauge_votes.yaml
@@ -1,14 +1,7 @@
 name: Review vLAURA Votes
 
-on:
-  pull_request:
-    paths:
-      - "MaxiOps/vlaura_voting/**/input/*.csv"
-  workflow_dispatch:
-    inputs:
-      week-string:
-        description: "The week to review like YYYY-W##"
-        required: true
+# Intentionally bricked. Restore the trigger block to re-enable this workflow.
+on: {}
 
 jobs:
   review_votes:

--- a/.github/workflows/sync_fee_distribution_artifacts.yaml
+++ b/.github/workflows/sync_fee_distribution_artifacts.yaml
@@ -1,16 +1,7 @@
 name: Sync Fee Distribution Artifacts
 
-on:
-  repository_dispatch:
-    types: [fee_report_merged]
-  workflow_dispatch:
-    inputs:
-      start-date:
-        description: "Start date (YYYY-MM-DD) - leave empty for auto-detection"
-        required: false
-      end-date:
-        description: "End date (YYYY-MM-DD) - leave empty for auto-detection"
-        required: false
+# Intentionally bricked. Restore the trigger block to re-enable this workflow.
+on: {}
 
 jobs:
   sync_artifacts:


### PR DESCRIPTION
currently some of these are still running in forks apparently, this fixes that