### PR TITLE
Lazy-init Aura in payload reports to avoid subgraph 429 storms

### DIFF
--- a/action-scripts/brownie/scripts/reports.py
+++ b/action-scripts/brownie/scripts/reports.py
@@ -191,13 +191,13 @@ def _parse_aura_direct_incentive(transaction: dict, **kwargs) -> Optional[dict]:
     chain_id = kwargs["chain_id"]
     chain_name = AddrBook.chain_names_by_id.get(int(chain_id))
     chainbook = AddrBook(chain_name)
-    aura = Aura(chain_name)
     if not transaction.get("contractInputsValues") or not transaction.get(
         "contractMethod"
     ):
         return
     if not transaction["contractMethod"].get("name") == "fundPool":
         return
+    aura = Aura(chain_name)
     to_address = to_checksum_address(transaction["to"])
     switch_chain_if_needed(chain_id)
     tokenAddress = to_checksum_address(transaction["contractInputsValues"]["_token"])

--- a/action-scripts/brownie/scripts/script_utils.py
+++ b/action-scripts/brownie/scripts/script_utils.py
@@ -361,6 +361,14 @@ def run_tenderly_sim(network_id: str, safe_addr: str, transactions: list[dict]):
                 if not isinstance(value, str):
                     return original_parse_func(field_type, value)
 
+                if field_type == "address" and isinstance(value, str):
+                    stripped = value.strip()
+                    if stripped.startswith("0x") and len(stripped) == 42:
+                        return to_checksum_address(stripped)
+
+                if field_type == "bytes32" and value.startswith("0x"):
+                    return HexBytes(value)
+
                 # Arrays: Remove quotes by parsing as JSON and reformatting
                 if value.strip().startswith("[") and "]" in field_type:
                     try:

--- a/action-scripts/brownie/scripts/script_utils.py
+++ b/action-scripts/brownie/scripts/script_utils.py
@@ -361,14 +361,6 @@ def run_tenderly_sim(network_id: str, safe_addr: str, transactions: list[dict]):
                 if not isinstance(value, str):
                     return original_parse_func(field_type, value)
 
-                if field_type == "address" and isinstance(value, str):
-                    stripped = value.strip()
-                    if stripped.startswith("0x") and len(stripped) == 42:
-                        return to_checksum_address(stripped)
-
-                if field_type == "bytes32" and value.startswith("0x"):
-                    return HexBytes(value)
-
                 # Arrays: Remove quotes by parsing as JSON and reformatting
                 if value.strip().startswith("[") and "]" in field_type:
                     try:


### PR DESCRIPTION
## Summary
- Lazy-init `Aura()` in `_parse_aura_direct_incentive` only after confirming the tx is `fundPool`, avoiding Aura subgraph calls (and 429 retry storms) on unrelated payloads

## Context
PR #2840's `Process BIP PR` job spent ~30 minutes in `Generate Payload report` because every transaction triggered `Aura()` subgraph lookups, even when the payload had no `fundPool` calls.

## Test plan
- [ ] Merge and re-run CI on a BIP PR with non-Aura txs — payload report step should complete much faster
- [ ] Confirm `fundPool` payloads still get Aura PID prettification in reports