### PR TITLE
Set allow-unsafe-pr-checkout on fork PR report checkout

### DIFF
--- a/.github/workflows/run_reports_reusable.yaml
+++ b/.github/workflows/run_reports_reusable.yaml
@@ -42,6 +42,7 @@ jobs:
           ref: ${{ inputs.checkout_ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           fetch-depth: 0
+          allow-unsafe-pr-checkout: true
 
       - name: Switch to PR branch
         if: inputs.checkout_branch != ''


### PR DESCRIPTION
actions/checkout@v7 refuses to check out fork PR code from a pull_request_target context by default. The run_reports reusable workflow intentionally checks out fork head code (secrets are gated behind the 'external' environment), so opt in explicitly.